### PR TITLE
Fix async arg in flumine start main.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -73,7 +73,7 @@ def main():
 
     flumine = Flumine(recorder=recorder, settings={"certificate_login": False})
     try:
-        flumine.start(_async=False)
+        flumine.start(async_=False)
     except FlumineException as e:
         logging.critical("Major flumine error: %s" % e)
 


### PR DESCRIPTION
Noticed the error locally. The arg here: https://github.com/liampauling/flumine/blob/master/flumine/flumine.py#L34 suggests it should be `async_`