### PR TITLE
closes #178

### DIFF
--- a/flumine/clients/baseclient.py
+++ b/flumine/clients/baseclient.py
@@ -22,6 +22,7 @@ class BaseClient:
         commission_base: float = DEFAULT_COMMISSION_BASE,
         interactive_login: bool = False,
         id_: str = None,
+        order_stream: bool = True,
     ):
         self.id = id_ or create_short_uuid()
         self.betting_client = betting_client
@@ -29,6 +30,7 @@ class BaseClient:
         self.capital_base = capital_base
         self.commission_base = commission_base
         self.interactive_login = interactive_login
+        self.order_stream = order_stream
 
         self.account_details = None
         self.account_funds = None

--- a/flumine/streams/streams.py
+++ b/flumine/streams/streams.py
@@ -31,10 +31,10 @@ class Streams:
             strategy.streams.append(stream)
 
     def add_client(self, client: BaseClient) -> None:
-        if client.EXCHANGE == ExchangeType.SIMULATED:
-            self.add_simulated_order_stream()
-        elif client.EXCHANGE == ExchangeType.BETFAIR:
-            self.add_order_stream(client)
+        if client.order_stream:
+            # todo if paper_trade: add_simulated_order_stream()
+            if client.EXCHANGE == ExchangeType.BETFAIR:
+                self.add_order_stream(client)
 
     """ market data """
 

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -27,6 +27,7 @@ class BaseClientTest(unittest.TestCase):
         self.assertEqual(self.base_client.chargeable_transaction_count, 0)
         self.assertIsNone(self.base_client.execution)
         self.assertEqual(self.base_client.trading_controls, [])
+        self.assertTrue(self.base_client.order_stream)
 
     def test_login(self):
         with self.assertRaises(NotImplementedError):

--- a/tests/test_streams.py
+++ b/tests/test_streams.py
@@ -58,19 +58,19 @@ class StreamsTest(unittest.TestCase):
         self.streams(mock_strategy)
         self.assertEqual(len(mock_strategy.streams), 0)
 
-    @mock.patch("flumine.streams.streams.Streams.add_simulated_order_stream")
-    def test_add_client_simulated(self, mock_add_simulated_order_stream):
-        mock_client = mock.Mock()
-        mock_client.EXCHANGE = streams.ExchangeType.SIMULATED
-        self.streams.add_client(mock_client)
-        mock_add_simulated_order_stream.assert_called_with()
-
     @mock.patch("flumine.streams.streams.Streams.add_order_stream")
     def test_add_client_betfair(self, mock_add_order_stream):
-        mock_client = mock.Mock()
+        mock_client = mock.Mock(order_stream=True)
         mock_client.EXCHANGE = streams.ExchangeType.BETFAIR
         self.streams.add_client(mock_client)
         mock_add_order_stream.assert_called_with(mock_client)
+
+    @mock.patch("flumine.streams.streams.Streams.add_order_stream")
+    def test_add_client_no_order_stream(self, mock_add_order_stream):
+        mock_client = mock.Mock(order_stream=False)
+        mock_client.EXCHANGE = streams.ExchangeType.BETFAIR
+        self.streams.add_client(mock_client)
+        mock_add_order_stream.assert_not_called()
 
     @mock.patch("flumine.streams.streams.Streams._increment_stream_id")
     def test_add_stream_new(self, mock_increment):


### PR DESCRIPTION
allow order stream to be disabled (enabled by default)
remove incorrect add_simulated, this is for paper trading only