### PR TITLE
Simulated optimisations

### DIFF
--- a/flumine/backtest/simulated.py
+++ b/flumine/backtest/simulated.py
@@ -19,6 +19,8 @@ class Simulated:
 
     def __init__(self, order):
         self.order = order
+        self.size_matched = 0
+        self.average_price_matched = 0
         self.matched = []  # [(publishTime, price, size)..]
         self.size_cancelled = 0.0
         self.size_lapsed = 0.0
@@ -152,7 +154,7 @@ class Simulated:
                 else:
                     _size_matched = avail["size"]
                 _matched = (publish_time, avail["price"], round(_size_matched, 2))
-                self.matched.append(_matched)
+                self._update_matched(_matched)
             else:
                 break
 
@@ -180,7 +182,7 @@ class Simulated:
                     size = round(_order_type.liability / (actual_sp - 1), 2)
             else:
                 raise NotImplementedError()
-            self.matched.append((publish_time, actual_sp, size))
+            self._update_matched((publish_time, actual_sp, size))
 
     def _process_traded(self, publish_time: int, traded: dict) -> None:
         # calculate matched on MarketBook update
@@ -197,7 +199,7 @@ class Simulated:
             size = traded_size - self._piq
             size = round(min(self.size_remaining, size), 2)
             if size:
-                self.matched.append(
+                self._update_matched(
                     (
                         publish_time,
                         self.order.order_type.price,
@@ -221,20 +223,9 @@ class Simulated:
     def side(self) -> str:
         return self.order.side
 
-    @property
-    def average_price_matched(self) -> float:
-        if self.matched:
-            _, avg_price_matched = wap(self.matched)
-            return avg_price_matched
-        else:
-            return 0
-
-    @property
-    def size_matched(self) -> float:
-        if self.matched:
-            return sum(x[2] for x in self.matched)
-        else:
-            return 0
+    def _update_matched(self, data):
+        self.matched.append(data)
+        self.size_matched, self.average_price_matched = wap(self.matched)
 
     @property
     def size_remaining(self) -> float:

--- a/flumine/backtest/simulated.py
+++ b/flumine/backtest/simulated.py
@@ -232,8 +232,7 @@ class Simulated:
     @property
     def size_matched(self) -> float:
         if self.matched:
-            size_matched, _ = wap(self.matched)
-            return size_matched
+            return sum(x[2] for x in self.matched)
         else:
             return 0
 

--- a/tests/test_simulated.py
+++ b/tests/test_simulated.py
@@ -263,7 +263,8 @@ class SimulatedTest(unittest.TestCase):
     def test__process_sp_processed_semi(self):
         mock_runner = mock.Mock()
         mock_runner.sp.actual_sp = 12.20
-        self.simulated.matched = [(1234571, 10.0, 1)]
+        #self.simulated.matched = [(1234571, 10.0, 1)]
+        self.simulated._update_matched((1234571, 10.0, 1))
         self.simulated._process_sp(1234572, mock_runner)
         self.assertEqual(
             self.simulated.matched, [(1234571, 10.0, 1), (1234572, 12.2, 1)]
@@ -388,30 +389,26 @@ class SimulatedTest(unittest.TestCase):
 
     def test_average_price_matched(self):
         self.assertEqual(self.simulated.average_price_matched, 0)
-        self.simulated.matched = [(1234, 1, 2)]
+        self.simulated._update_matched((1234, 1, 2))
         self.assertEqual(self.simulated.average_price_matched, 1)
 
     def test_size_matched(self):
         self.assertEqual(self.simulated.size_matched, 0)
-        self.simulated.matched = [(4321, 1, 2)]
+        self.simulated._update_matched((4321, 1, 2))
         self.assertEqual(self.simulated.size_matched, 2)
 
-    @mock.patch(
-        "flumine.backtest.simulated.Simulated.size_matched",
-        new_callable=mock.PropertyMock,
-    )
-    def test_size_remaining(self, mock_size_matched):
-        mock_size_matched.return_value = 0
+    def test_size_remaining(self):
         self.assertEqual(self.simulated.size_remaining, 2)
-        mock_size_matched.return_value = 1
+        self.simulated._update_matched((1234, 1, 1))
         self.assertEqual(self.simulated.size_remaining, 1)
 
-    @mock.patch(
-        "flumine.backtest.simulated.Simulated.size_matched",
-        new_callable=mock.PropertyMock,
-    )
-    def test_size_remaining_multi(self, mock_size_matched):
-        mock_size_matched.return_value = 0.1
+    # @mock.patch(
+    #     "flumine.backtest.simulated.Simulated.size_matched",
+    #     new_callable=mock.PropertyMock,
+    # )
+    def test_size_remaining_multi(self):#, mock_size_matched):
+        #mock_size_matched.return_value = 0.1
+        self.simulated._update_matched((1234, 1, 0.1))
         self.simulated.size_cancelled = 0.2
         self.simulated.size_lapsed = 0.3
         self.simulated.size_voided = 0.4
@@ -422,37 +419,19 @@ class SimulatedTest(unittest.TestCase):
         self.simulated.order.order_type.ORDER_TYPE = OrderTypes.LIMIT_ON_CLOSE
         self.assertEqual(self.simulated.size_remaining, 0)
 
-    @mock.patch(
-        "flumine.backtest.simulated.Simulated.average_price_matched",
-        new_callable=mock.PropertyMock,
-    )
-    @mock.patch(
-        "flumine.backtest.simulated.Simulated.size_matched",
-        new_callable=mock.PropertyMock,
-    )
-    def test_profit_back(self, mock_size_matched, mock_average_price_matched):
+    def test_profit_back(self):
         self.assertEqual(self.simulated.profit, 0)
         self.simulated.order.runner_status = "WINNER"
-        mock_size_matched.return_value = 2.00
-        mock_average_price_matched.return_value = 10.0
+        self.simulated._update_matched((1234, 10.0, 2.0))
         self.assertEqual(self.simulated.profit, 18.0)
         self.simulated.order.runner_status = "LOSER"
         self.assertEqual(self.simulated.profit, -2.0)
 
-    @mock.patch(
-        "flumine.backtest.simulated.Simulated.average_price_matched",
-        new_callable=mock.PropertyMock,
-    )
-    @mock.patch(
-        "flumine.backtest.simulated.Simulated.size_matched",
-        new_callable=mock.PropertyMock,
-    )
-    def test_profit_back(self, mock_size_matched, mock_average_price_matched):
+    def test_profit_lay(self):
         self.simulated.order.side = "LAY"
         self.assertEqual(self.simulated.profit, 0)
         self.simulated.order.runner_status = "WINNER"
-        mock_size_matched.return_value = 2.00
-        mock_average_price_matched.return_value = 10.0
+        self.simulated._update_matched((1234, 10.0, 2.0))
         self.assertEqual(self.simulated.profit, -18.0)
         self.simulated.order.runner_status = "LOSER"
         self.assertEqual(self.simulated.profit, 2.0)


### PR DESCRIPTION
size_matched and average_price_matched are now recalculated every time  Simulated.matched is updated.

On my personal machine, running a particular backtest, the time-taken has dropped from 58 seconds to 34 seconds.