### PR TITLE
Client control 'transaction_limit' None bug fix

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,18 @@
 Release History
 ---------------
 
+1.8.2 (2020-07-06)
++++++++++++++++++++
+
+**Improvements**
+
+-
+
+**Bug Fixes**
+
+- Simulated bug fix on when data is not recorded from the beginning
+- Client control 'None' bug fix
+
 1.8.1 (2020-06-30)
 +++++++++++++++++++
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,7 +8,7 @@ Release History
 
 **Improvements**
 
--
+- Previous 'middle' added to simulated
 
 **Bug Fixes**
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -341,7 +341,7 @@ Release History
 **Improvements**
 
 - black fmt
-- _async renamed to async_ to match bflw
+- _async renamed to `async_` to match bflw
 - py3.7 added to travis
 - #28 readme update
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,7 +8,7 @@ Release History
 
 **Improvements**
 
-- Previous 'middle' added to simulated
+- Previous 'middle' and 'matched' added to simulated
 
 **Bug Fixes**
 

--- a/flumine/__version__.py
+++ b/flumine/__version__.py
@@ -1,6 +1,6 @@
 __title__ = "flumine"
 __description__ = "Betfair trading framework"
 __url__ = "https://github.com/liampauling/flumine"
-__version__ = "1.8.1"
+__version__ = "1.8.2"
 __author__ = "Liam Pauling"
 __license__ = "MIT"

--- a/flumine/controls/clientcontrols.py
+++ b/flumine/controls/clientcontrols.py
@@ -76,7 +76,7 @@ class MaxOrderCount(BaseControl):
 
     def _check_transaction_count(self, transaction_count: int) -> None:
         self.transaction_count += transaction_count
-        if self.transaction_count > self.transaction_limit:
+        if self.transaction_limit and self.transaction_count > self.transaction_limit:
             logger.error(
                 "Transaction limit reached",
                 extra={

--- a/flumine/markets/middleware.py
+++ b/flumine/markets/middleware.py
@@ -57,7 +57,7 @@ class RunnerAnalytics:
     def __init__(self, runner: RunnerBook):
         self._runner = runner
         self.traded = {}
-        self._traded_volume = []  # runner.ex.traded_volume
+        self._traded_volume = runner.ex.traded_volume
 
     def __call__(self, runner: RunnerBook):
         self.traded = self._calculate_traded(runner)
@@ -65,9 +65,7 @@ class RunnerAnalytics:
         self._runner = runner
 
     def _calculate_traded(self, runner: RunnerBook) -> dict:
-        if self._traded_volume == {}:
-            return {}
-        elif self._traded_volume == runner.ex.traded_volume:
+        if self._traded_volume == runner.ex.traded_volume:
             return {}
         else:
             c_v, p_v, traded_dictionary = {}, {}, {}

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -80,7 +80,9 @@ class RunnerAnalyticsTest(unittest.TestCase):
 
     def test_init(self):
         self.assertEqual(self.runner_analytics._runner, self.mock_runner)
-        self.assertEqual(self.runner_analytics._traded_volume, [])
+        self.assertEqual(
+            self.runner_analytics._traded_volume, self.mock_runner.ex.traded_volume
+        )
         self.assertEqual(self.runner_analytics.traded, {})
 
     @mock.patch("flumine.markets.middleware.RunnerAnalytics._calculate_traded")
@@ -95,6 +97,7 @@ class RunnerAnalyticsTest(unittest.TestCase):
         self.assertEqual(self.runner_analytics._runner, mock_runner)
 
     def test__calculate_traded_dict_empty(self):
+        self.runner_analytics._traded_volume = []
         mock_runner = mock.Mock()
         mock_runner.ex.traded_volume = []
         self.assertEqual(self.runner_analytics._calculate_traded(mock_runner), {})


### PR DESCRIPTION
Simulated bug fix
- On initial start incorrectly calculates all historic traded data available for matching during cycle
- Fix removes this by setting the current traded volume on init
- Bug present when restricting data to inplay or data was recorded after initial opening