### PR TITLE
Move remove_markets logic to process_closed_markets (previously not c…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,6 @@ env:
 
 jobs:
   include:
-    - name: "Tests: python 3.5"
-      python: 3.5
-      script:
-        - coverage run --source=flumine setup.py test
     - name: "Tests: python 3.6"
       python: 3.6
       script:

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,14 @@
 Release History
 ---------------
 
+1.9.3 (2020-07-17)
++++++++++++++++++++
+
+**Bug Fixes**
+
+- Move remove_markets logic to process_closed_markets (previously not called if no orders)
+- Travis remove py3.5
+
 1.9.2 (2020-07-16)
 +++++++++++++++++++
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Support for market and custom streaming data (order, score and custom polling da
 
 [join slack group](https://betfairlightweight.herokuapp.com)
 
-Currently tested on Python 3.5, 3.6, 3.7 and 3.8.
+Currently tested on Python 3.6, 3.7 and 3.8.
 
 ## installation
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,7 +30,7 @@ Support for market, order and custom streaming data.
 
 [join slack group](https://betfairlightweight.herokuapp.com)
 
-Currently tested on Python 3.5, 3.6, 3.7 and 3.8.
+Currently tested on Python 3.6, 3.7 and 3.8.
 
 ## installation
 

--- a/flumine/__version__.py
+++ b/flumine/__version__.py
@@ -1,6 +1,6 @@
 __title__ = "flumine"
 __description__ = "Betfair trading framework"
 __url__ = "https://github.com/liampauling/flumine"
-__version__ = "1.9.2"
+__version__ = "1.9.3"
 __author__ = "Liam Pauling"
 __license__ = "MIT"

--- a/flumine/baseflumine.py
+++ b/flumine/baseflumine.py
@@ -225,6 +225,15 @@ class BaseFlumine:
         self.log_control(event)
         logger.info("Market closed", extra={"market_id": market.market_id, **self.info})
 
+        # check for markets that have been closed for x seconds and remove
+        closed_markets = [
+            m
+            for m in self.markets
+            if m.elapsed_seconds_closed and m.elapsed_seconds_closed > 3600
+        ]
+        for market in closed_markets:
+            self._remove_market(market)
+
     def _process_cleared_orders(self, event):
         market_id = event.event.market_id
         market = self.markets.markets.get(market_id)
@@ -257,15 +266,6 @@ class BaseFlumine:
                     "bet_count": cleared_market.bet_count,
                 },
             )
-
-        # check for markets that have been closed for x seconds
-        closed_markets = [
-            m
-            for m in self.markets
-            if m.elapsed_seconds_closed and m.elapsed_seconds_closed > 3600
-        ]
-        for market in closed_markets:
-            self._remove_market(market)
 
     def _process_end_flumine(self) -> None:
         for strategy in self.strategies:

--- a/flumine/baseflumine.py
+++ b/flumine/baseflumine.py
@@ -229,7 +229,7 @@ class BaseFlumine:
         closed_markets = [
             m
             for m in self.markets
-            if m.elapsed_seconds_closed and m.elapsed_seconds_closed > 3600
+            if m.closed and m.elapsed_seconds_closed and m.elapsed_seconds_closed > 3600
         ]
         for market in closed_markets:
             self._remove_market(market)

--- a/tests/test_baseflumine.py
+++ b/tests/test_baseflumine.py
@@ -191,11 +191,9 @@ class BaseFlumineTest(unittest.TestCase):
         mock_strategy = mock.Mock()
         mock_strategy.stream_ids = [1, 2, 3]
         self.base_flumine.strategies = [mock_strategy]
-        mock_market = mock.Mock()
+        mock_market = mock.Mock(elapsed_seconds_closed=None)
         mock_market.market_book.streaming_unique_id = 2
-        mock_markets = mock.Mock()
-        mock_markets.markets = {"1.23": mock_market}
-        self.base_flumine.markets = mock_markets
+        self.base_flumine.markets._markets = {"1.23": mock_market}
         mock_event = mock.Mock()
         mock_market_book = mock.Mock(market_id="1.23")
         mock_event.event = mock_market_book
@@ -212,16 +210,34 @@ class BaseFlumineTest(unittest.TestCase):
 
     @mock.patch("flumine.baseflumine.BaseFlumine.info")
     def test__process_close_market_no_market(self, mock_info):
-        mock_market = mock.Mock()
+        mock_market = mock.Mock(elapsed_seconds_closed=None)
         mock_market.market_book.streaming_unique_id = 2
-        mock_markets = mock.Mock()
-        mock_markets.markets = {"1.23": mock_market}
-        self.base_flumine.markets = mock_markets
+        self.base_flumine.markets._markets = {"1.23": mock_market}
         mock_event = mock.Mock()
         mock_market_book = mock.Mock(market_id="1.45")
         mock_event.event = mock_market_book
         self.base_flumine._process_close_market(mock_event)
         mock_market.close_market.assert_not_called()
+
+    @mock.patch("flumine.baseflumine.BaseFlumine.info")
+    @mock.patch("flumine.baseflumine.BaseFlumine.log_control")
+    def test__process_close_market_closed(self, mock_log_control, mock_info):
+        mock_strategy = mock.Mock()
+        mock_strategy.stream_ids = [1, 2, 3]
+        self.base_flumine.strategies = [mock_strategy]
+        mock_market = mock.Mock(elapsed_seconds_closed=None)
+        mock_market.market_book.streaming_unique_id = 2
+        self.base_flumine.markets._markets = {
+            "1.23": mock_market,
+            "4.56": mock.Mock(market_id="4.56", elapsed_seconds_closed=25),
+            "7.89": mock.Mock(market_id="7.89", elapsed_seconds_closed=3601),
+        }
+        mock_event = mock.Mock()
+        mock_market_book = mock.Mock(market_id="1.23")
+        mock_event.event = mock_market_book
+        self.base_flumine._process_close_market(mock_event)
+
+        self.assertEqual(len(self.base_flumine.markets._markets), 2)
 
     @mock.patch("flumine.baseflumine.events")
     @mock.patch("flumine.baseflumine.BaseFlumine.log_control")
@@ -255,16 +271,6 @@ class BaseFlumineTest(unittest.TestCase):
         mock_event = mock.Mock()
         mock_event.event.orders = []
         self.base_flumine._process_cleared_markets(mock_event)
-
-    def test__process_cleared_markets_closed(self):
-        self.base_flumine.markets._markets = {
-            "123": mock.Mock(market_id="123", elapsed_seconds_closed=25),
-            "456": mock.Mock(market_id="456", elapsed_seconds_closed=3601),
-        }
-        mock_event = mock.Mock()
-        mock_event.event.orders = []
-        self.base_flumine._process_cleared_markets(mock_event)
-        self.assertEqual(len(self.base_flumine.markets._markets), 1)
 
     def test__process_end_flumine(self):
         self.base_flumine._process_end_flumine()

--- a/tests/test_baseflumine.py
+++ b/tests/test_baseflumine.py
@@ -191,7 +191,7 @@ class BaseFlumineTest(unittest.TestCase):
         mock_strategy = mock.Mock()
         mock_strategy.stream_ids = [1, 2, 3]
         self.base_flumine.strategies = [mock_strategy]
-        mock_market = mock.Mock(elapsed_seconds_closed=None)
+        mock_market = mock.Mock(closed=False, elapsed_seconds_closed=None)
         mock_market.market_book.streaming_unique_id = 2
         self.base_flumine.markets._markets = {"1.23": mock_market}
         mock_event = mock.Mock()
@@ -210,7 +210,7 @@ class BaseFlumineTest(unittest.TestCase):
 
     @mock.patch("flumine.baseflumine.BaseFlumine.info")
     def test__process_close_market_no_market(self, mock_info):
-        mock_market = mock.Mock(elapsed_seconds_closed=None)
+        mock_market = mock.Mock(closed=False, elapsed_seconds_closed=None)
         mock_market.market_book.streaming_unique_id = 2
         self.base_flumine.markets._markets = {"1.23": mock_market}
         mock_event = mock.Mock()
@@ -225,19 +225,24 @@ class BaseFlumineTest(unittest.TestCase):
         mock_strategy = mock.Mock()
         mock_strategy.stream_ids = [1, 2, 3]
         self.base_flumine.strategies = [mock_strategy]
-        mock_market = mock.Mock(elapsed_seconds_closed=None)
+        mock_market = mock.Mock(closed=False, elapsed_seconds_closed=None)
         mock_market.market_book.streaming_unique_id = 2
         self.base_flumine.markets._markets = {
             "1.23": mock_market,
-            "4.56": mock.Mock(market_id="4.56", elapsed_seconds_closed=25),
-            "7.89": mock.Mock(market_id="7.89", elapsed_seconds_closed=3601),
+            "4.56": mock.Mock(market_id="4.56", closed=True, elapsed_seconds_closed=25),
+            "7.89": mock.Mock(
+                market_id="7.89", closed=True, elapsed_seconds_closed=3601
+            ),
+            "1.01": mock.Mock(
+                market_id="1.01", closed=False, elapsed_seconds_closed=3601
+            ),
         }
         mock_event = mock.Mock()
         mock_market_book = mock.Mock(market_id="1.23")
         mock_event.event = mock_market_book
         self.base_flumine._process_close_market(mock_event)
 
-        self.assertEqual(len(self.base_flumine.markets._markets), 2)
+        self.assertEqual(len(self.base_flumine.markets._markets), 3)
 
     @mock.patch("flumine.baseflumine.events")
     @mock.patch("flumine.baseflumine.BaseFlumine.log_control")


### PR DESCRIPTION
…alled if no orders as it only executes on cleared market call which requires orders)

Travis remove py3.5