### PR TITLE
Adds check incase removal_adjustment_factor is None when processing runner removal

### DIFF
--- a/flumine/markets/middleware.py
+++ b/flumine/markets/middleware.py
@@ -96,7 +96,10 @@ class SimulatedMiddleware(Middleware):
                         # todo cancel if not PERSIST
                         # todo does a market version bump occur if withdrawal is below the limit?
                         pass
-                    if removal_adjustment_factor >= WIN_MINIMUM_ADJUSTMENT_FACTOR:
+                    if (
+                        removal_adjustment_factor
+                        and removal_adjustment_factor >= WIN_MINIMUM_ADJUSTMENT_FACTOR
+                    ):
                         # todo place market
                         for match in order.simulated.matched:
                             match[1] = round(

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -133,6 +133,7 @@ class SimulatedMiddlewareTest(unittest.TestCase):
         mock_order = mock.Mock(simulated=mock_simulated)
         mock_market = mock.Mock(blotter=[mock_order])
         self.middleware._process_runner_removal(mock_market, 12345, 0, None)
+        self.assertEqual(mock_order.simulated.matched, [[123, 8.6, 10]])
 
     def test__process_simulated_orders(self):
         mock_market_book = mock.Mock()

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -127,6 +127,13 @@ class SimulatedMiddlewareTest(unittest.TestCase):
         self.assertEqual(mock_order.simulated.matched, [])
         self.assertEqual(mock_order.simulated.size_voided, 10)
 
+    def test__process_runner_removal_none(self):
+        mock_simulated = mock.MagicMock(matched=[[123, 8.6, 10]])
+        mock_simulated.__bool__.return_value = True
+        mock_order = mock.Mock(simulated=mock_simulated)
+        mock_market = mock.Mock(blotter=[mock_order])
+        self.middleware._process_runner_removal(mock_market, 12345, 0, None)
+
     def test__process_simulated_orders(self):
         mock_market_book = mock.Mock()
         mock_order = mock.Mock()


### PR DESCRIPTION
```
File "flumine/markets/middleware.py", line 100, in _process_runner_removal
    removal_adjustment_factor >= WIN_MINIMUM_ADJUSTMENT_FACTOR
TypeError: '>=' not supported between instances of 'NoneType' and 'float'
```

I've had a few occasions this happened on the dogs, an example market was 1.171375157. This is does seem like an edge case hence the naive fix.