### PR TITLE
#187 runner context additions

### DIFF
--- a/flumine/order/trade.py
+++ b/flumine/order/trade.py
@@ -32,6 +32,8 @@ class Trade:
         fill_kill=None,
         offset=None,
         green=None,
+        place_reset_seconds: float = 0.0,  # seconds to wait since `runner_context.reset` before allowing another order
+        reset_seconds: float = 0.0,  # seconds to wait since `runner_context.place` before allowing another order
     ):
         self.id = uuid.uuid1()
         self.market_id = market_id
@@ -45,6 +47,8 @@ class Trade:
         self.fill_kill = fill_kill  # todo
         self.offset = offset  # todo
         self.green = green  # todo
+        self.place_reset_seconds = place_reset_seconds
+        self.reset_seconds = reset_seconds
         self.orders = []  # all orders linked to trade
         self.offset_orders = []  # pending offset orders once initial order has matched
         self.status_log = []

--- a/tests/test_trade.py
+++ b/tests/test_trade.py
@@ -24,6 +24,8 @@ class TradeTest(unittest.TestCase):
             self.mock_fill_kill,
             self.mock_offset,
             self.mock_green,
+            12,
+            34,
         )
 
     def test_init(self):
@@ -41,6 +43,8 @@ class TradeTest(unittest.TestCase):
         self.assertIsNotNone(self.trade.date_time_created)
         self.assertIsNone(self.trade.date_time_complete)
         self.assertIsNone(self.trade.market_notes)
+        self.assertEqual(self.trade.place_reset_seconds, 12)
+        self.assertEqual(self.trade.reset_seconds, 34)
 
     @mock.patch("flumine.order.trade.get_market_notes")
     def test_update_market_notes(self, mock_get_market_notes):


### PR DESCRIPTION
strategy
 - max live trade count allows more than one live order per strategy/runner
 - max trade count limits total number of trades per strategy/runner
trade
 - place reset seconds, allows delay between orders being placed based on last place
 - reset seconds, allows delay between orders being placed based on last reset (execution complete)