### PR TITLE
Flumine performance improvements

### DIFF
--- a/flumine/backtest/simulated.py
+++ b/flumine/backtest/simulated.py
@@ -59,7 +59,9 @@ class Simulated:
 
             if runner.status == "REMOVED":
                 return self._create_place_response(
-                    bet_id, status="FAILURE", error_code="RUNNER_REMOVED",
+                    bet_id,
+                    status="FAILURE",
+                    error_code="RUNNER_REMOVED",
                 )
 
             available_to_back = get_price(runner.ex.available_to_back, 0) or 1.01
@@ -101,8 +103,8 @@ class Simulated:
 
             # calculate position in queue
             for avail in available:
-                if avail["price"] == price:
-                    self._piq = avail["size"]
+                if avail.price == price:
+                    self._piq = avail.size
                     break
 
             logger.debug(
@@ -136,7 +138,8 @@ class Simulated:
             )
         else:
             return SimulatedCancelResponse(
-                status="FAILURE", error_code="BET_ACTION_ERROR",  # todo ?
+                status="FAILURE",
+                error_code="BET_ACTION_ERROR",  # todo ?
             )
 
     def update(self, instruction: dict):
@@ -151,7 +154,8 @@ class Simulated:
             return SimulatedUpdateResponse(status="SUCCESS")
         else:
             return SimulatedCancelResponse(
-                status="FAILURE", error_code="BET_ACTION_ERROR",
+                status="FAILURE",
+                error_code="BET_ACTION_ERROR",
             )
 
     def _get_runner(self, market_book: MarketBook) -> RunnerBook:
@@ -169,16 +173,16 @@ class Simulated:
         for avail in available:
             if size_remaining == 0:
                 break
-            elif (self.side == "BACK" and price <= avail["price"]) or (
-                self.side == "LAY" and price >= avail["price"]
+            elif (self.side == "BACK" and price <= avail.price) or (
+                self.side == "LAY" and price >= avail.price
             ):
                 _size_remaining = size_remaining
-                size_remaining = max(size_remaining - avail["size"], 0)
+                size_remaining = max(size_remaining - avail.size, 0)
                 if size_remaining == 0:
                     _size_matched = _size_remaining
                 else:
-                    _size_matched = avail["size"]
-                _matched = [publish_time, avail["price"], round(_size_matched, 2)]
+                    _size_matched = avail.size
+                _matched = [publish_time, avail.price, round(_size_matched, 2)]
                 self._update_matched(_matched)
             else:
                 break

--- a/flumine/execution/simulatedexecution.py
+++ b/flumine/execution/simulatedexecution.py
@@ -16,8 +16,7 @@ class SimulatedExecution(BaseExecution):
     REPLACE_LATENCY = 0.280
 
     def handler(self, order_package: BaseOrderPackage) -> None:
-        """ Only uses _thread_pool if paper_trade
-        """
+        """Only uses _thread_pool if paper_trade"""
         if order_package.package_type == OrderPackageType.PLACE:
             func = self.execute_place
         elif order_package.package_type == OrderPackageType.CANCEL:
@@ -107,7 +106,9 @@ class SimulatedExecution(BaseExecution):
                 else:
                     order.lapsed()  # todo do not carry out replace
                 self._order_logger(
-                    order, cancel_instruction_report, OrderPackageType.CANCEL,
+                    order,
+                    cancel_instruction_report,
+                    OrderPackageType.CANCEL,
                 )
 
                 # place new order

--- a/flumine/markets/middleware.py
+++ b/flumine/markets/middleware.py
@@ -8,7 +8,8 @@ from ..utils import get_price, wap
 logger = logging.getLogger(__name__)
 
 WIN_MINIMUM_ADJUSTMENT_FACTOR = 2.5
-PLACE_MINIMUM_ADJUSTMENT_FACTOR = 0  # todo implement correctly (https://en-betfair.custhelp.com/app/answers/detail/a_id/406)
+# todo implement correctly (https://en-betfair.custhelp.com/app/answers/detail/a_id/406)
+PLACE_MINIMUM_ADJUSTMENT_FACTOR = 0
 
 
 class Middleware:
@@ -88,7 +89,8 @@ class SimulatedMiddleware(Middleware):
                     order.simulated.matched = []
                     order.simulated.size_voided = order.order_type.size
                     logger.warning(
-                        "Order voided on non runner {0}".format(order.selection_id),
+                        "Order voided on non runner {0}".format(
+                            order.selection_id),
                         extra=order.info,
                     )
                 else:
@@ -103,7 +105,8 @@ class SimulatedMiddleware(Middleware):
                         # todo place market
                         for match in order.simulated.matched:
                             match[1] = round(
-                                match[1] * (1 - (removal_adjustment_factor / 100)), 2
+                                match[1] *
+                                (1 - (removal_adjustment_factor / 100)), 2
                             )
                         _, order.simulated.average_price_matched = wap(
                             order.simulated.matched
@@ -127,7 +130,8 @@ class SimulatedMiddleware(Middleware):
     @staticmethod
     def _process_runner(market_analytics: dict, runner: RunnerBook) -> None:
         try:
-            runner_analytics = market_analytics[(runner.selection_id, runner.handicap)]
+            runner_analytics = market_analytics[(
+                runner.selection_id, runner.handicap)]
         except KeyError:
             runner_analytics = market_analytics[
                 (runner.selection_id, runner.handicap)
@@ -157,9 +161,9 @@ class RunnerAnalytics:
             c_v, p_v, traded = {}, {}, {}
             # create dictionaries
             for i in runner.ex.traded_volume:
-                c_v[i["price"]] = i["size"]
+                c_v[i.price] = i.size
             for i in self._traded_volume:
-                p_v[i["price"]] = i["size"]  # todo cache from previous run?
+                p_v[i.price] = i.size  # todo cache from previous run?
             # calculate difference
             for key in c_v.keys():
                 if key in p_v:

--- a/flumine/streams/historicalstream.py
+++ b/flumine/streams/historicalstream.py
@@ -99,7 +99,18 @@ class HistoricalStream(BaseStream):
     def handle_output(self) -> None:
         pass
 
-    def create_generator(self):
+    def create_update_generator(self):
+        self.historical_stream = HistoricalGeneratorStream(
+            file_path=self.market_filter,
+            listener=self._listener,
+            operation=self.operation,
+        )
+        return self.historical_stream.get_update_generator()
+
+    def apply_update(self, update) -> dict:
+        return self.historical_stream._update(update)
+
+    def create_snap_generator(self):
         stream = HistoricalGeneratorStream(
             file_path=self.market_filter,
             listener=self._listener,

--- a/flumine/utils.py
+++ b/flumine/utils.py
@@ -39,7 +39,7 @@ def file_line_count(file_path: str) -> int:
 
 def chunks(l: list, n: int) -> list:
     for i in range(0, len(l), n):
-        yield l[i : i + n]
+        yield l[i: i + n]
 
 
 def create_cheap_hash(txt: str, length: int = 15) -> str:
@@ -89,7 +89,7 @@ def get_nearest_price(price, cutoffs=CUTOFFS):
 
 def get_price(data: list, level: int) -> Optional[float]:
     try:
-        return data[level]["price"]
+        return data[level].price  # ["price"]
     except KeyError:
         return
     except IndexError:
@@ -100,7 +100,7 @@ def get_price(data: list, level: int) -> Optional[float]:
 
 def get_size(data: list, level: int) -> Optional[float]:
     try:
-        return data[level]["size"]
+        return data[level].size  # ["size"]
     except KeyError:
         return
     except IndexError:

--- a/tests/test_fluminebacktest.py
+++ b/tests/test_fluminebacktest.py
@@ -1,4 +1,5 @@
 import unittest
+import json
 from unittest import mock
 
 from flumine import FlumineBacktest
@@ -37,9 +38,10 @@ class FlumineBacktestTest(unittest.TestCase):
         mock__unpatch_datetime,
     ):
         mock_stream = mock.Mock()
+        mock_gen = mock.Mock(return_value=[json.dumps({"pt": 1598896706888})])
+        mock_stream.create_update_generator.return_value = mock_gen
         mock_market_book = mock.Mock()
-        mock_gen = mock.Mock(return_value=[[mock_market_book]])
-        mock_stream.create_generator.return_value = mock_gen
+        mock_stream.apply_update.return_value = [mock_market_book]
         self.flumine.streams._streams = [mock_stream]
         self.flumine.run()
         mock__monkey_patch_datetime.assert_called_with()

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,6 +1,8 @@
 import unittest
 from unittest import mock
 
+from betfairlightweight.resources import PriceSize, PriceSizeList
+
 from flumine.markets.middleware import (
     Middleware,
     SimulatedMiddleware,
@@ -214,7 +216,7 @@ class RunnerAnalyticsTest(unittest.TestCase):
 
     def test__calculate_traded_dict_new(self):
         mock_runner = mock.Mock()
-        mock_runner.ex.traded_volume = [{"price": 1.01, "size": 69}]
+        mock_runner.ex.traded_volume = PriceSizeList([[1.01, 69]])
         self.runner_analytics._traded_volume = []
         self.assertEqual(
             self.runner_analytics._calculate_traded(mock_runner), {1.01: 69.0}
@@ -222,13 +224,16 @@ class RunnerAnalyticsTest(unittest.TestCase):
 
     def test__calculate_traded_dict_new_multi(self):
         mock_runner = mock.Mock()
-        mock_runner.ex.traded_volume = [
-            {"price": 1.01, "size": 69},
-            {"price": 10, "size": 32},
-        ]
-        self.runner_analytics._traded_volume = [{"price": 1.01, "size": 30}]
+        mock_runner.ex.traded_volume = PriceSizeList(
+            [
+                [1.01, 69],
+                [10, 32],
+            ]
+        )
+        self.runner_analytics._traded_volume = [PriceSize(price=1.01, size=30)]
         self.assertEqual(
-            self.runner_analytics._calculate_traded(mock_runner), {1.01: 39.0, 10: 32},
+            self.runner_analytics._calculate_traded(mock_runner),
+            {1.01: 39.0, 10: 32},
         )
 
     def test__calculate_middle(self):
@@ -236,11 +241,11 @@ class RunnerAnalyticsTest(unittest.TestCase):
         mock_runner.ex.available_to_back = []
         mock_runner.ex.available_to_lay = []
         self.assertEqual(self.runner_analytics._calculate_middle(mock_runner), 500.5)
-        mock_runner.ex.available_to_back = [{"price": 2.00}]
-        mock_runner.ex.available_to_lay = [{"price": 2.02}]
+        mock_runner.ex.available_to_back = PriceSizeList([[2.00, 10]])
+        mock_runner.ex.available_to_lay = PriceSizeList([[2.02, 10]])
         self.assertEqual(self.runner_analytics._calculate_middle(mock_runner), 2.01)
-        mock_runner.ex.available_to_back = [{"price": 10.00}]
-        mock_runner.ex.available_to_lay = [{"price": 15.5}]
+        mock_runner.ex.available_to_back = PriceSizeList([[10.00, 10]])
+        mock_runner.ex.available_to_lay = PriceSizeList([[15.5, 10]])
         self.assertEqual(self.runner_analytics._calculate_middle(mock_runner), 12.75)
 
     def test__calculate_matched(self):

--- a/tests/test_simulated.py
+++ b/tests/test_simulated.py
@@ -1,6 +1,8 @@
 import unittest
 from unittest import mock
 
+from betfairlightweight.resources import PriceSizeList
+
 from flumine.backtest import simulated
 from flumine.order.ordertype import OrderTypes
 
@@ -87,8 +89,8 @@ class SimulatedTest(unittest.TestCase):
         mock_client = mock.Mock(best_price_execution=True)
         mock_market_book = mock.Mock()
         mock_runner = mock.Mock()
-        mock_runner.ex.available_to_back = [{"price": 12, "size": 120}]
-        mock_runner.ex.available_to_lay = [{"price": 13, "size": 120}]
+        mock_runner.ex.available_to_back = PriceSizeList([[12, 120]])
+        mock_runner.ex.available_to_lay = PriceSizeList([[13, 120]])
         mock__get_runner.return_value = mock_runner
         resp = self.simulated.place(mock_client, mock_market_book, {}, 1)
         self.assertEqual(resp.average_price_matched, 12)
@@ -102,13 +104,10 @@ class SimulatedTest(unittest.TestCase):
         mock_client = mock.Mock(best_price_execution=True)
         mock_market_book = mock.Mock()
         mock_runner = mock.Mock()
-        mock_runner.ex.available_to_back = [{"price": 10, "size": 120}]
-        mock_runner.ex.available_to_lay = [
-            {"price": 10.5, "size": 120},
-            {"price": 11.5, "size": 10},
-            {"price": 12, "size": 22},
-            {"price": 15, "size": 32},
-        ]
+        mock_runner.ex.available_to_back = PriceSizeList([[10, 120]])
+        mock_runner.ex.available_to_lay = PriceSizeList(
+            [[10.5, 120], [11.5, 10], [12, 22], [15, 32]]
+        )
         mock__get_runner.return_value = mock_runner
         resp = self.simulated.place(mock_client, mock_market_book, {}, 1)
         self.assertEqual(resp.average_price_matched, 0)
@@ -121,8 +120,8 @@ class SimulatedTest(unittest.TestCase):
         mock_client = mock.Mock(best_price_execution=False)
         mock_market_book = mock.Mock()
         mock_runner = mock.Mock()
-        mock_runner.ex.available_to_back = [{"price": 15, "size": 120}]
-        mock_runner.ex.available_to_lay = [{"price": 16, "size": 120}]
+        mock_runner.ex.available_to_back = PriceSizeList([[15, 120]])
+        mock_runner.ex.available_to_lay = PriceSizeList([[16, 120]])
         mock__get_runner.return_value = mock_runner
         resp = self.simulated.place(mock_client, mock_market_book, {}, 1)
         self.assertEqual(resp.status, "FAILURE")
@@ -135,8 +134,8 @@ class SimulatedTest(unittest.TestCase):
         self.simulated.order.side = "LAY"
         mock_market_book = mock.Mock()
         mock_runner = mock.Mock()
-        mock_runner.ex.available_to_back = [{"price": 11, "size": 120}]
-        mock_runner.ex.available_to_lay = [{"price": 12, "size": 120}]
+        mock_runner.ex.available_to_back = PriceSizeList([[11, 120]])
+        mock_runner.ex.available_to_lay = PriceSizeList([[12, 120]])
         mock__get_runner.return_value = mock_runner
         resp = self.simulated.place(mock_client, mock_market_book, {}, 1)
         self.assertEqual(resp.average_price_matched, 12)
@@ -151,13 +150,10 @@ class SimulatedTest(unittest.TestCase):
         self.simulated.order.side = "LAY"
         mock_market_book = mock.Mock()
         mock_runner = mock.Mock()
-        mock_runner.ex.available_to_back = [
-            {"price": 10.5, "size": 120},
-            {"price": 11.5, "size": 10},
-            {"price": 12, "size": 22},
-            {"price": 14, "size": 32},
-        ]
-        mock_runner.ex.available_to_lay = [{"price": 15, "size": 32}]
+        mock_runner.ex.available_to_back = PriceSizeList(
+            [[10.5, 120], [11.5, 120], [12, 22], [14, 32]]
+        )
+        mock_runner.ex.available_to_lay = PriceSizeList([[15, 32]])
         mock__get_runner.return_value = mock_runner
         resp = self.simulated.place(mock_client, mock_market_book, {}, 1)
         self.assertEqual(resp.average_price_matched, 0)
@@ -171,8 +167,8 @@ class SimulatedTest(unittest.TestCase):
         self.simulated.order.side = "LAY"
         mock_market_book = mock.Mock()
         mock_runner = mock.Mock()
-        mock_runner.ex.available_to_back = [{"price": 10, "size": 120}]
-        mock_runner.ex.available_to_lay = [{"price": 10.5, "size": 120}]
+        mock_runner.ex.available_to_back = PriceSizeList([[10, 120]])
+        mock_runner.ex.available_to_lay = PriceSizeList([[10.5, 120]])
         mock__get_runner.return_value = mock_runner
         resp = self.simulated.place(mock_client, mock_market_book, {}, 1)
         self.assertEqual(resp.status, "FAILURE")
@@ -185,8 +181,8 @@ class SimulatedTest(unittest.TestCase):
         self.simulated.order.side = "BACK"
         mock_market_book = mock.Mock()
         mock_runner = mock.Mock()
-        mock_runner.ex.available_to_back = [{"price": 10, "size": 120}]
-        mock_runner.ex.available_to_lay = [{"price": 10.5, "size": 120}]
+        mock_runner.ex.available_to_back = PriceSizeList([[10, 120]])
+        mock_runner.ex.available_to_lay = PriceSizeList([[10.5, 120]])
         mock_runner.status = "REMOVED"
         mock__get_runner.return_value = mock_runner
         resp = self.simulated.place(mock_client, mock_market_book, {}, 1)
@@ -236,7 +232,8 @@ class SimulatedTest(unittest.TestCase):
         mock_runner = mock.Mock(selection_id=1234, handicap=1)
         mock_market_book.runners = [mock_runner]
         self.assertEqual(
-            self.simulated._get_runner(mock_market_book), mock_runner,
+            self.simulated._get_runner(mock_market_book),
+            mock_runner,
         )
         mock_runner = mock.Mock(selection_id=134, handicap=1)
         mock_market_book.runners = [mock_runner]
@@ -249,22 +246,25 @@ class SimulatedTest(unittest.TestCase):
     )
     def test__process_price_matched_back(self, mock_side):
         self.simulated._process_price_matched(
-            1234567, 12.0, 2.00, [{"price": 15, "size": 120}]
+            1234567, 12.0, 2.00, PriceSizeList([[15, 120]])
         )
         self.assertEqual(self.simulated.matched, [[1234567, 15, 2]])
+
         self.simulated.matched = []
         self.simulated._process_price_matched(
-            1234568, 12.0, 2.00, [{"price": 15, "size": 1}, {"price": 12, "size": 1}]
+            1234568, 12.0, 2.00, PriceSizeList([[15, 1], [12, 1]], reverse=True)
         )
         self.assertEqual(self.simulated.matched, [[1234568, 15, 1], [1234568, 12, 1]])
+
         self.simulated.matched = []
         self.simulated._process_price_matched(
-            1234569, 12.0, 2.00, [{"price": 15, "size": 1}, {"price": 12, "size": 0.5}]
+            1234569, 12.0, 2.00, PriceSizeList([[15, 1], [12, 0.5]], reverse=True)
         )
         self.assertEqual(self.simulated.matched, [[1234569, 15, 1], [1234569, 12, 0.5]])
+
         self.simulated.matched = []
         self.simulated._process_price_matched(
-            1234570, 12.0, 2.00, [{"price": 15, "size": 1}, {"price": 11, "size": 0.5}]
+            1234570, 12.0, 2.00, PriceSizeList([[15, 1], [11, 0.5]], reverse=True)
         )
         self.assertEqual(self.simulated.matched, [[1234570, 15, 1]])
 
@@ -275,12 +275,12 @@ class SimulatedTest(unittest.TestCase):
     )
     def test__process_price_matched_lay(self, mock_side):
         self.simulated._process_price_matched(
-            1234571, 3.0, 20.00, [{"price": 2.02, "size": 120}]
+            1234571, 3.0, 20.00, PriceSizeList([[2.02, 120]])
         )
         self.assertEqual(self.simulated.matched, [[1234571, 2.02, 20]])
         self.simulated.matched = []
         self.simulated._process_price_matched(
-            1234571, 3.0, 20.00, [{"price": 2.02, "size": 1}, {"price": 3, "size": 20}]
+            1234571, 3.0, 20.00, PriceSizeList([[2.02, 1], [3, 20]])
         )
         self.assertEqual(self.simulated.matched, [[1234571, 2.02, 1], [1234571, 3, 19]])
         self.simulated.matched = []
@@ -288,14 +288,14 @@ class SimulatedTest(unittest.TestCase):
             1234571,
             3.0,
             20.00,
-            [{"price": 2.02, "size": 1}, {"price": 2.9, "size": 0.5}],
+            PriceSizeList([[2.02, 1], [2.9, 0.5]]),
         )
         self.assertEqual(
             self.simulated.matched, [[1234571, 2.02, 1], [1234571, 2.9, 0.5]]
         )
         self.simulated.matched = []
         self.simulated._process_price_matched(
-            1234571, 3.0, 20.00, [{"price": 3, "size": 1}, {"price": 11, "size": 0.5}]
+            1234571, 3.0, 20.00, PriceSizeList([[3, 1], [11, 0.5]])
         )
         self.assertEqual(self.simulated.matched, [[1234571, 3, 1]])
 

--- a/tests/test_streams.py
+++ b/tests/test_streams.py
@@ -1,6 +1,8 @@
 import unittest
 from unittest import mock
 
+from betfairlightweight.test_data import create_market_definition_data
+
 from flumine.streams import streams, datastream, historicalstream
 from flumine.streams.basestream import BaseStream
 from flumine.streams.simulatedorderstream import CurrentOrders
@@ -459,7 +461,14 @@ class TestStream(unittest.TestCase):
 
     def test__process(self):
         self.stream._process(
-            [{"id": "1.23", "img": {1: 2}, "marketDefinition": {"runners": []}}], 12345
+            [
+                {
+                    "id": "1.23",
+                    "img": {1: 2},
+                    "marketDefinition": create_market_definition_data(),
+                }
+            ],
+            12345,
         )
         self.assertEqual(len(self.stream._caches), 1)
 

--- a/tests/test_streams.py
+++ b/tests/test_streams.py
@@ -441,7 +441,7 @@ class TestHistoricalStream(unittest.TestCase):
 
     @mock.patch("flumine.streams.historicalstream.HistoricalGeneratorStream")
     def test_create_generator(self, mock_generator):
-        generator = self.stream.create_generator()
+        generator = self.stream.create_snap_generator()
         mock_generator.assert_called_with(
             file_path={"test": "me"},
             listener=self.stream._listener,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,6 +2,7 @@ import logging
 import unittest
 from unittest import mock
 
+from betfairlightweight.resources import PriceSizeList
 from flumine import utils, FlumineException
 
 
@@ -20,7 +21,8 @@ class UtilsTest(unittest.TestCase):
 
     def test_create_cheap_hash(self):
         self.assertEqual(
-            utils.create_cheap_hash("test"), utils.create_cheap_hash("test"),
+            utils.create_cheap_hash("test"),
+            utils.create_cheap_hash("test"),
         )
         self.assertEqual(len(utils.create_cheap_hash("test", 16)), 16)
 
@@ -42,35 +44,35 @@ class UtilsTest(unittest.TestCase):
         self.assertEqual(utils.get_nearest_price(2.0099), 2.00)
 
     def test_get_price(self):
+        entries = PriceSizeList([[12, 120], [34, 120]])
+
         self.assertEqual(
-            utils.get_price(
-                [{"price": 12, "size": 120}, {"price": 34, "size": 120}], 0
-            ),
+            utils.get_price(entries, 0),
             12,
         )
+
         self.assertEqual(
-            utils.get_price(
-                [{"price": 12, "size": 120}, {"price": 34, "size": 120}], 1
-            ),
+            utils.get_price(entries, 1),
             34,
         )
-        self.assertIsNone(
-            utils.get_price([{"price": 12, "size": 120}, {"price": 34, "size": 120}], 3)
-        )
-        self.assertIsNone(utils.get_price([], 3))
+
+        self.assertIsNone(utils.get_price(entries, 3))
+        self.assertIsNone(utils.get_size([], 3))
 
     def test_get_size(self):
+        entries = PriceSizeList([[12, 12], [34, 34]])
+
         self.assertEqual(
-            utils.get_size([{"price": 12, "size": 12}, {"price": 34, "size": 34}], 0),
+            utils.get_size(entries, 0),
             12,
         )
+
         self.assertEqual(
-            utils.get_size([{"price": 12, "size": 12}, {"price": 34, "size": 34}], 1),
+            utils.get_size(entries, 1),
             34,
         )
-        self.assertIsNone(
-            utils.get_size([{"price": 12, "size": 12}, {"price": 34, "size": 34}], 3)
-        )
+
+        self.assertIsNone(utils.get_size(entries, 3))
         self.assertIsNone(utils.get_size([], 3))
 
     def test_get_sp(self):


### PR DESCRIPTION
Hi folks!

Due to very long execution times of our backtests, I made a performance profile. Almost half of the total execution time is used to serialize and then instantiate the `MarketBook` class. Using the lightweight option only partially reduces this performance overhead. I think unifying the caches and the betting data-structures could have a huge impact on overall performance. AFAIK this would also decrease the framework overhead in production, since the same cache is used. 

![Screenshot 2020-09-09 at 09 51 34](https://user-images.githubusercontent.com/9663231/92570541-52614c80-f282-11ea-88df-84a8e0b811f2.png)

### Prototype

I started to do a prototype implementation to validate this approach. I refactored parts of the `RunnerBook` cache to remove the overhead for serializing the `price`/`size` lists in the underlying [betfair](https://github.com/liampauling/betfair) project. This corresponds to the second back line marked in the profiling screenshot. This reduced the runtime for our benchmarks by a little over 10%, which verifies the assumptions made based on the profiling.

Since the `MarketBook` instances now partially hold data references to the cache, the historic stream used in the backtest had to be updated. pending orders are now processed before the cache is updated.

The current implementation is a WIP and not polished. After our initial findings we however wanted to coordinate with you, since the changes are quite extensive. I will create the corresponding PR to the betfair project and link it here.

Best Regards,
Felix