### PR TITLE
Iss287 separator

### DIFF
--- a/flumine/order/order.py
+++ b/flumine/order/order.py
@@ -2,6 +2,7 @@ import uuid
 import logging
 import datetime
 from enum import Enum
+import string
 from typing import Union, Optional
 from betfairlightweight import filters
 from betfairlightweight.resources.bettingresources import CurrentOrder
@@ -15,7 +16,11 @@ from ..backtest.simulated import Simulated
 logger = logging.getLogger(__name__)
 
 
-VALID_CUSTOMER_ORDER_REF_CHARACTERS = {"-", ".", "_", "+", "*", ":", ";", "~"}
+VALID_CUSTOMER_ORDER_REF_CHARACTERS = (
+    {"-", ".", "_", "+", "*", ":", ";", "~"}
+    .union(set(string.ascii_letters))
+    .union(set(string.digits))
+)
 
 
 class OrderStatus(Enum):
@@ -274,11 +279,11 @@ class BetfairOrder(BaseOrder):
         self.sep = sep
 
     @property
-    def sep(self):
+    def sep(self) -> str:
         return self._sep
 
     @sep.setter
-    def sep(self, new_sep: str) -> str:
+    def sep(self, new_sep: str) -> None:
         if is_valid_customer_order_ref_character(new_sep):
             self._sep = new_sep
         else:
@@ -426,8 +431,4 @@ def is_valid_customer_order_ref_character(c: str) -> bool:
     if len(c) != 1:
         return False
     else:
-        if c.isalnum():
-            return True
-        elif c in VALID_CUSTOMER_ORDER_REF_CHARACTERS:
-            return True
-        return False
+        return c in VALID_CUSTOMER_ORDER_REF_CHARACTERS

--- a/flumine/order/order.py
+++ b/flumine/order/order.py
@@ -15,7 +15,7 @@ from ..backtest.simulated import Simulated
 logger = logging.getLogger(__name__)
 
 
-VALID_CUSTOMER_ORDER_REF_CHARACTERS = {".", "_", "+", "*", ":", ";", "~"}
+VALID_CUSTOMER_ORDER_REF_CHARACTERS = {"-", ".", "_", "+", "*", ":", ";", "~"}
 
 
 class OrderStatus(Enum):
@@ -222,7 +222,7 @@ class BaseOrder:
 
     @property
     def customer_order_ref(self) -> str:
-        return "{0}-{1}".format(self.trade.strategy.name_hash, self.id)
+        return "{0}{1}{2}".format(self.trade.strategy.name_hash, self.sep, self.id)
 
     @property
     def info(self) -> dict:
@@ -257,6 +257,32 @@ class BaseOrder:
 class BetfairOrder(BaseOrder):
 
     EXCHANGE = ExchangeType.BETFAIR
+
+    def __init__(
+        self,
+        trade,
+        side: str,
+        order_type: Union[LimitOrder, LimitOnCloseOrder, MarketOnCloseOrder],
+        handicap: float = 0,
+        sep="-",
+    ):
+        super().__init__(
+            trade=trade, side=side, order_type=order_type, handicap=handicap
+        )
+
+        self._sep = "-"  # DEFAULT VALUE
+        self.sep = sep
+
+    @property
+    def sep(self):
+        return self._sep
+
+    @sep.setter
+    def sep(self, new_sep: str) -> str:
+        if is_valid_customer_order_ref_character(new_sep):
+            self._sep = new_sep
+        else:
+            raise ValueError(f"Invalid sep: {new_sep}")
 
     # updates
     def place(self, publish_time: int) -> None:

--- a/flumine/order/order.py
+++ b/flumine/order/order.py
@@ -15,6 +15,9 @@ from ..backtest.simulated import Simulated
 logger = logging.getLogger(__name__)
 
 
+VALID_CUSTOMER_ORDER_REF_CHARACTERS = {".", "_", "+", "*", ":", ";", "~"}
+
+
 class OrderStatus(Enum):
     # Pending
     PENDING = "Pending"  # pending exchange processing
@@ -384,3 +387,21 @@ class BetfairOrder(BaseOrder):
             return self.current_order.size_voided or 0.0
         except AttributeError:
             return 0.0
+
+
+def is_valid_customer_order_ref_character(c: str) -> bool:
+    """
+    Check if the separator is of length 1, and a valid
+    character, as defined in the Betfair documentation is:
+
+    CustomerRef can contain: upper/lower chars, digits, chars
+     : - . _ + * : ; ~ only.
+    """
+    if len(c) != 1:
+        return False
+    else:
+        if c.isalnum():
+            return True
+        elif c in VALID_CUSTOMER_ORDER_REF_CHARACTERS:
+            return True
+        return False

--- a/tests/test_order.py
+++ b/tests/test_order.py
@@ -9,8 +9,7 @@ from flumine.order.order import (
     ExchangeType,
     OrderTypes,
     OrderStatus,
-    is_valid_customer_order_ref_character,
-    VALID_CUSTOMER_ORDER_REF_CHARACTERS,
+    VALID_BETFAIR_CUSTOMER_ORDER_REF_CHARACTERS,
 )
 from flumine.exceptions import OrderUpdateError
 
@@ -233,6 +232,21 @@ class BaseOrderTest(unittest.TestCase):
     def test_repr(self):
         self.assertEqual(repr(self.order), "Order None: None")
 
+    def test_set_and_get_sep(self):
+        self.order.sep = "a"
+        self.assertEqual("a", self.order.sep)
+
+    def test_customer_order_ref(self):
+        self.order.trade.strategy.name_hash = "my_name_hash"
+        self.order.id = 1234
+        self.assertEqual("my_name_hash-1234", self.order.customer_order_ref)
+
+        self.order.sep = "I"
+        self.assertEqual("my_name_hashI1234", self.order.customer_order_ref)
+
+        self.order.sep = "O"
+        self.assertEqual("my_name_hashO1234", self.order.customer_order_ref)
+
 
 class BetfairOrderTest(unittest.TestCase):
     def setUp(self) -> None:
@@ -452,45 +466,30 @@ class BetfairOrderTest(unittest.TestCase):
             },
         )
 
-    def test_set_and_get_sep(self):
-        self.order.sep = "a"
-        self.assertEqual("a", self.order.sep)
-
     def test_set_invalid_sep(self):
         with self.assertRaises(ValueError):
             self.order.sep = "@"
-
-    def test_customer_order_ref(self):
-        self.order.trade.strategy.name_hash = "my_name_hash"
-        self.order.id = 1234
-        self.assertEqual("my_name_hash-1234", self.order.customer_order_ref)
-
-        self.order.sep = "I"
-        self.assertEqual("my_name_hashI1234", self.order.customer_order_ref)
-
-        self.order.sep = "O"
-        self.assertEqual("my_name_hashO1234", self.order.customer_order_ref)
 
 
 class IsValidCustomerOrderRefTestCase(unittest.TestCase):
     def test_letters_True(self):
         # ascii_letters contains a-z and A-Z
         for c in string.ascii_letters:
-            self.assertTrue(is_valid_customer_order_ref_character(c))
+            self.assertTrue(BetfairOrder.is_valid_customer_order_ref_character(c))
 
     def test_2letters_False(self):
-        self.assertFalse(is_valid_customer_order_ref_character("aB"))
-        self.assertFalse(is_valid_customer_order_ref_character("CD"))
+        self.assertFalse(BetfairOrder.is_valid_customer_order_ref_character("aB"))
+        self.assertFalse(BetfairOrder.is_valid_customer_order_ref_character("CD"))
 
     def test_digits_True(self):
         # string.digits contains digits 0-9
         for c in string.digits:
-            self.assertTrue(is_valid_customer_order_ref_character(c))
+            self.assertTrue(BetfairOrder.is_valid_customer_order_ref_character(c))
 
     def test_special_characters_True(self):
-        for c in VALID_CUSTOMER_ORDER_REF_CHARACTERS:
-            self.assertTrue(is_valid_customer_order_ref_character((c)))
+        for c in VALID_BETFAIR_CUSTOMER_ORDER_REF_CHARACTERS:
+            self.assertTrue(BetfairOrder.is_valid_customer_order_ref_character((c)))
 
     def test_special_characters_False(self):
         for c in list('!"£$%'):
-            self.assertFalse(is_valid_customer_order_ref_character((c)))
+            self.assertFalse(BetfairOrder.is_valid_customer_order_ref_character((c)))

--- a/tests/test_order.py
+++ b/tests/test_order.py
@@ -452,6 +452,25 @@ class BetfairOrderTest(unittest.TestCase):
             },
         )
 
+    def test_set_and_get_sep(self):
+        self.order.sep = "a"
+        self.assertEqual("a", self.order.sep)
+
+    def test_set_invalid_sep(self):
+        with self.assertRaises(ValueError):
+            self.order.sep = "@"
+
+    def test_customer_order_ref(self):
+        self.order.trade.strategy.name_hash = "my_name_hash"
+        self.order.id = 1234
+        self.assertEqual("my_name_hash-1234", self.order.customer_order_ref)
+
+        self.order.sep = "I"
+        self.assertEqual("my_name_hashI1234", self.order.customer_order_ref)
+
+        self.order.sep = "O"
+        self.assertEqual("my_name_hashO1234", self.order.customer_order_ref)
+
 
 class IsValidCustomerOrderRefTestCase(unittest.TestCase):
     def test_letters_True(self):

--- a/tests/test_order.py
+++ b/tests/test_order.py
@@ -1,3 +1,4 @@
+import string
 import unittest
 import datetime
 from unittest import mock
@@ -8,6 +9,8 @@ from flumine.order.order import (
     ExchangeType,
     OrderTypes,
     OrderStatus,
+    is_valid_customer_order_ref_character,
+    VALID_CUSTOMER_ORDER_REF_CHARACTERS,
 )
 from flumine.exceptions import OrderUpdateError
 
@@ -448,3 +451,27 @@ class BetfairOrderTest(unittest.TestCase):
                 "customer_order_ref": self.order.customer_order_ref,
             },
         )
+
+
+class IsValidCustomerOrderRefTestCase(unittest.TestCase):
+    def test_letters_True(self):
+        # ascii_letters contains a-z and A-Z
+        for c in string.ascii_letters:
+            self.assertTrue(is_valid_customer_order_ref_character(c))
+
+    def test_2letters_False(self):
+        self.assertFalse(is_valid_customer_order_ref_character("aB"))
+        self.assertFalse(is_valid_customer_order_ref_character("CD"))
+
+    def test_digits_True(self):
+        # string.digits contains digits 0-9
+        for c in string.digits:
+            self.assertTrue(is_valid_customer_order_ref_character(c))
+
+    def test_special_characters_True(self):
+        for c in VALID_CUSTOMER_ORDER_REF_CHARACTERS:
+            self.assertTrue(is_valid_customer_order_ref_character((c)))
+
+    def test_special_characters_False(self):
+        for c in list('!"£$%'):
+            self.assertFalse(is_valid_customer_order_ref_character((c)))


### PR DESCRIPTION
The purpose of this change is to allow users to use the customer_order_ref field to help identify orders, while preserving current behaviour. Specifically, this will not increase the risk of collisions.