### PR TITLE
#192 correctly lapse limit orders when market version is bumped durin…

### DIFF
--- a/flumine/markets/middleware.py
+++ b/flumine/markets/middleware.py
@@ -99,10 +99,6 @@ class SimulatedMiddleware(Middleware):
                         extra=order.info,
                     )
                 else:
-                    if order.status == OrderStatus.EXECUTABLE:
-                        # todo cancel if not PERSIST
-                        # todo does a market version bump occur if withdrawal is below the limit?
-                        pass
                     if (
                         removal_adjustment_factor
                         and removal_adjustment_factor >= WIN_MINIMUM_ADJUSTMENT_FACTOR


### PR DESCRIPTION
…g a 'material change' as per docs:

 `However, to prevent falsely blocking bets we keep track of the last
  material change (which we define as one performed under suspension**)
  and will only accept bets placed with that version or later.`