### PR TITLE
prevent thread pool exhaustion by using async flag to free up threads…

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -194,3 +194,7 @@ Raises errors on strategy functions, see [Error Handling](/advanced/#error-handl
 ### max_execution_workers
 
 Max number of workers in execution thread pool
+
+### async_place_orders
+
+Place orders sent with place orders flag, prevents waiting for bet delay

--- a/flumine/baseflumine.py
+++ b/flumine/baseflumine.py
@@ -208,7 +208,8 @@ class BaseFlumine:
                 market.update_market_catalogue = False
 
     def _process_current_orders(self, event: events.CurrentOrdersEvent) -> None:
-        process_current_orders(self.markets, self.strategies, event)  # update state
+        # update state
+        process_current_orders(self.markets, self.strategies, event, self.log_control)
         for market in self.markets:
             if market.closed is False:
                 for strategy in self.strategies:

--- a/flumine/config.py
+++ b/flumine/config.py
@@ -16,3 +16,5 @@ current_time = None  # used for backtesting
 raise_errors = False  # used for call_check_market / call_process_market_book
 
 max_execution_workers = 32  # max number of workers in execution thread pool
+
+async_place_orders = False  # async place orders

--- a/flumine/execution/baseexecution.py
+++ b/flumine/execution/baseexecution.py
@@ -127,8 +127,9 @@ class BaseExecution:
         )
         if package_type == OrderPackageType.PLACE:
             order.responses.placed(instruction_report)
-            order.bet_id = instruction_report.bet_id
-            self.flumine.log_control(OrderEvent(order))
+            if instruction_report.bet_id:
+                order.bet_id = instruction_report.bet_id
+                self.flumine.log_control(OrderEvent(order))
         elif package_type == OrderPackageType.CANCEL:
             order.responses.cancelled(instruction_report)
         elif package_type == OrderPackageType.UPDATE:

--- a/flumine/execution/betfairexecution.py
+++ b/flumine/execution/betfairexecution.py
@@ -28,7 +28,10 @@ class BetfairExecution(BaseExecution):
                         order, instruction_report, OrderPackageType.PLACE
                     )
                     if instruction_report.status == "SUCCESS":
-                        order.executable()
+                        if instruction_report.order_status == "PENDING":
+                            pass  # async request pending processing
+                        else:
+                            order.executable()  # let process.py pick it up
                     elif instruction_report.status == "FAILURE":
                         order.lapsed()  # todo correct?
                     elif instruction_report.status == "TIMEOUT":

--- a/flumine/execution/transaction.py
+++ b/flumine/execution/transaction.py
@@ -93,6 +93,7 @@ class Transaction:
             packages += self._create_order_package(
                 self._pending_place,
                 OrderPackageType.PLACE,
+                async_=True,
             )
         if self._pending_cancel:
             packages += self._create_order_package(
@@ -136,7 +137,7 @@ class Transaction:
             return True
 
     def _create_order_package(
-        self, orders: list, package_type: OrderPackageType
+        self, orders: list, package_type: OrderPackageType, async_: bool = False
     ) -> list:
         # group orders by marketVersion
         orders_grouped = defaultdict(list)
@@ -155,6 +156,7 @@ class Transaction:
                         package_type=package_type,
                         bet_delay=self.market.market_book.bet_delay,
                         market_version=market_version,
+                        async_=async_,
                     )
                 )
         orders.clear()

--- a/flumine/execution/transaction.py
+++ b/flumine/execution/transaction.py
@@ -30,9 +30,10 @@ class Transaction:
             t.place_order(order)  # both executed on transaction __exit__
     """
 
-    def __init__(self, market, id_: int):
+    def __init__(self, market, id_: int, async_place_orders: bool):
         self.market = market
         self._id = id_  # unique per market only
+        self._async_place_orders = async_place_orders
         self._pending_orders = False
         self._pending_place = []  # list of (<Order>, market_version)
         self._pending_cancel = []  # list of (<Order>, None)
@@ -96,7 +97,7 @@ class Transaction:
             packages += self._create_order_package(
                 self._pending_place,
                 OrderPackageType.PLACE,
-                async_=True,
+                async_=self._async_place_orders,
             )
         if self._pending_cancel:
             packages += self._create_order_package(

--- a/flumine/markets/market.py
+++ b/flumine/markets/market.py
@@ -4,6 +4,7 @@ from typing import Optional
 from collections import defaultdict
 from betfairlightweight.resources.bettingresources import MarketBook, MarketCatalogue
 
+from .. import config
 from .blotter import Blotter
 from ..execution.transaction import Transaction
 
@@ -60,9 +61,13 @@ class Market:
             extra=self.info,
         )
 
-    def transaction(self) -> Transaction:
+    def transaction(
+        self, async_place_orders: bool = config.async_place_orders
+    ) -> Transaction:
         self._transaction_id += 1
-        return Transaction(self, id_=self._transaction_id)
+        return Transaction(
+            self, id_=self._transaction_id, async_place_orders=async_place_orders
+        )
 
     # order
     def place_order(

--- a/flumine/order/order.py
+++ b/flumine/order/order.py
@@ -303,7 +303,9 @@ class BetfairOrder(BaseOrder):
         runner_context.place()
 
     def cancel(self, size_reduction: float = None) -> None:
-        if self.order_type.ORDER_TYPE == OrderTypes.LIMIT:
+        if self.bet_id is None:
+            raise OrderUpdateError("Order does not currently have a betId.")
+        elif self.order_type.ORDER_TYPE == OrderTypes.LIMIT:
             if size_reduction and self.size_remaining - size_reduction < 0:
                 raise OrderUpdateError("Size reduction too large")
             if self.status != OrderStatus.EXECUTABLE:
@@ -316,7 +318,9 @@ class BetfairOrder(BaseOrder):
             )
 
     def update(self, new_persistence_type: str) -> None:
-        if self.order_type.ORDER_TYPE == OrderTypes.LIMIT:
+        if self.bet_id is None:
+            raise OrderUpdateError("Order does not currently have a betId.")
+        elif self.order_type.ORDER_TYPE == OrderTypes.LIMIT:
             if self.order_type.persistence_type == new_persistence_type:
                 raise OrderUpdateError("Persistence types match")
             elif self.status != OrderStatus.EXECUTABLE:
@@ -327,7 +331,12 @@ class BetfairOrder(BaseOrder):
             raise OrderUpdateError("Only LIMIT orders can be updated.")
 
     def replace(self, new_price: float) -> None:
-        if self.order_type.ORDER_TYPE in [OrderTypes.LIMIT, OrderTypes.LIMIT_ON_CLOSE]:
+        if self.bet_id is None:
+            raise OrderUpdateError("Order does not currently have a betId.")
+        elif self.order_type.ORDER_TYPE in [
+            OrderTypes.LIMIT,
+            OrderTypes.LIMIT_ON_CLOSE,
+        ]:
             if self.order_type.price == new_price:
                 raise OrderUpdateError("Prices match")
             elif self.status != OrderStatus.EXECUTABLE:

--- a/flumine/order/order.py
+++ b/flumine/order/order.py
@@ -303,7 +303,7 @@ class BetfairOrder(BaseOrder):
 
     def cancel(self, size_reduction: float = None) -> None:
         if self.bet_id is None:
-            raise OrderUpdateError("Order does not currently have a betId.")
+            raise OrderUpdateError("Order does not currently have a betId")
         elif self.order_type.ORDER_TYPE == OrderTypes.LIMIT:
             if size_reduction and self.size_remaining - size_reduction < 0:
                 raise OrderUpdateError("Size reduction too large")
@@ -313,12 +313,12 @@ class BetfairOrder(BaseOrder):
             self.cancelling()
         else:
             raise OrderUpdateError(
-                "Only LIMIT orders can be cancelled or partially cancelled once placed."
+                "Only LIMIT orders can be cancelled or partially cancelled once placed"
             )
 
     def update(self, new_persistence_type: str) -> None:
         if self.bet_id is None:
-            raise OrderUpdateError("Order does not currently have a betId.")
+            raise OrderUpdateError("Order does not currently have a betId")
         elif self.order_type.ORDER_TYPE == OrderTypes.LIMIT:
             if self.order_type.persistence_type == new_persistence_type:
                 raise OrderUpdateError("Persistence types match")
@@ -327,11 +327,11 @@ class BetfairOrder(BaseOrder):
             self.order_type.persistence_type = new_persistence_type
             self.updating()
         else:
-            raise OrderUpdateError("Only LIMIT orders can be updated.")
+            raise OrderUpdateError("Only LIMIT orders can be updated")
 
     def replace(self, new_price: float) -> None:
         if self.bet_id is None:
-            raise OrderUpdateError("Order does not currently have a betId.")
+            raise OrderUpdateError("Order does not currently have a betId")
         elif self.order_type.ORDER_TYPE in [
             OrderTypes.LIMIT,
             OrderTypes.LIMIT_ON_CLOSE,
@@ -344,7 +344,7 @@ class BetfairOrder(BaseOrder):
             self.replacing()
         else:
             raise OrderUpdateError(
-                "Only LIMIT or LIMIT_ON_CLOSE orders can be replaced."
+                "Only LIMIT or LIMIT_ON_CLOSE orders can be replaced"
             )
 
     # instructions

--- a/flumine/order/process.py
+++ b/flumine/order/process.py
@@ -9,7 +9,20 @@ from ..events.events import OrderEvent
 logger = logging.getLogger(__name__)
 
 """
-Handles orphan orders by creating empty trade and order data from CurrentOrder object/
+Various functions to update current order status
+and update status.
+
+Loop through each current order:
+    order = Lookup order in market using marketId and orderId
+    if order is None (not present locally):
+        create local order using data and make executable #todo!!!
+    if betId is None (async placement):
+        Update betId and log through logging_control
+    if order betId != current_order betId:
+        Get order using current_order betId due to replace request (new betId)
+    if order:
+        update current status
+        process
 """
 
 
@@ -43,7 +56,9 @@ def process_current_orders(
                 else:
                     continue
 
-            if order.bet_id is None:  # async bet pending processing
+            if (
+                order.bet_id is None and current_order.bet_id
+            ):  # async bet pending processing
                 order.bet_id = current_order.bet_id
                 log_control(OrderEvent(order))
                 order.executable()
@@ -61,6 +76,7 @@ def process_current_orders(
 def process_current_order(order: BaseOrder):
     if order.status == OrderStatus.EXECUTABLE:
         if order.order_type.ORDER_TYPE == OrderTypes.LIMIT:
+            # todo use `order.current_order.status` ?
             if order.size_voided:
                 order.voided()
             elif order.size_lapsed:

--- a/flumine/order/process.py
+++ b/flumine/order/process.py
@@ -4,19 +4,18 @@ from ..markets.markets import Markets
 from ..order.order import BaseOrder, OrderStatus, OrderTypes
 from ..order.trade import Trade
 from ..strategy.strategy import Strategies, STRATEGY_NAME_HASH_LENGTH
+from ..events.events import OrderEvent
 
 logger = logging.getLogger(__name__)
 
 """
-Handles trade fillkill / green etc.
 Handles orphan orders by creating empty trade and order data from CurrentOrder object/
 """
 
 
-# todo handle fillkill/green/
-
-
-def process_current_orders(markets: Markets, strategies: Strategies, event):
+def process_current_orders(
+    markets: Markets, strategies: Strategies, event, log_control
+) -> None:
     for current_orders in event.event:
         for current_order in current_orders.orders:
             order_id = current_order.customer_order_ref[STRATEGY_NAME_HASH_LENGTH + 1 :]
@@ -24,7 +23,7 @@ def process_current_orders(markets: Markets, strategies: Strategies, event):
                 market_id=current_order.market_id,
                 order_id=order_id,
             )
-            if not order:
+            if order is None:
                 logger.warning(
                     "Order %s not present in blotter" % current_order.bet_id,
                     extra={
@@ -43,7 +42,12 @@ def process_current_orders(markets: Markets, strategies: Strategies, event):
                     order.executable()  # todo correct?
                 else:
                     continue
-            if order.bet_id != current_order.bet_id:  # replaceOrder handling (hacky)
+
+            if order.bet_id is None:  # async bet pending processing
+                order.bet_id = current_order.bet_id
+                log_control(OrderEvent(order))
+                order.executable()
+            elif order.bet_id != current_order.bet_id:  # replaceOrder handling (hacky)
                 order = markets.get_order_from_bet_id(
                     market_id=current_order.market_id,
                     bet_id=current_order.bet_id,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -11,3 +11,4 @@ class ConfigTest(unittest.TestCase):
         self.assertIsNone(config.current_time)
         self.assertFalse(config.raise_errors)
         self.assertEqual(config.max_execution_workers, 32)
+        self.assertFalse(config.async_place_orders)

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -161,6 +161,16 @@ class BaseExecutionTest(unittest.TestCase):
         mock_order.responses.placed.assert_called_with(mock_instruction_report)
         self.mock_flumine.log_control.assert_called_with(mock_order_event(mock_order))
 
+    def test__order_logger_place_no_bet_id(self):
+        mock_order = mock.Mock(bet_id=123)
+        mock_instruction_report = mock.Mock(bet_id=None)
+        self.execution._order_logger(
+            mock_order, mock_instruction_report, OrderPackageType.PLACE
+        )
+        self.assertEqual(mock_order.bet_id, 123)
+        mock_order.responses.placed.assert_called_with(mock_instruction_report)
+        self.mock_flumine.log_control.assert_not_called()
+
     def test__order_logger_cancel(self):
         mock_order = mock.Mock()
         mock_instruction_report = mock.Mock()
@@ -228,6 +238,36 @@ class BetfairExecutionTest(unittest.TestCase):
             mock_order, mock_instruction_report, OrderPackageType.PLACE
         )
         mock_order.executable.assert_called_with()
+        mock_order.trade.__enter__.assert_called_with()
+        mock_order.trade.__exit__.assert_called_with(None, None, None)
+        mock_order_package.client.add_transaction.assert_called_with(1)
+
+    @mock.patch("flumine.execution.betfairexecution.BetfairExecution._order_logger")
+    @mock.patch("flumine.execution.betfairexecution.BetfairExecution.place")
+    @mock.patch("flumine.execution.betfairexecution.BetfairExecution._execution_helper")
+    def test_execute_place_success_pending(
+        self, mock__execution_helper, mock_place, mock__order_logger
+    ):
+        mock_session = mock.Mock()
+        mock_order = mock.Mock()
+        mock_order.trade.__enter__ = mock.Mock()
+        mock_order.trade.__exit__ = mock.Mock()
+        mock_order_package = mock.MagicMock()
+        mock_order_package.__len__.return_value = 1
+        mock_order_package.__iter__ = mock.Mock(return_value=iter([mock_order]))
+        mock_order_package.info = {}
+        mock_report = mock.Mock()
+        mock_instruction_report = mock.Mock(status="SUCCESS", order_status="PENDING")
+        mock_report.place_instruction_reports = [mock_instruction_report]
+        mock__execution_helper.return_value = mock_report
+        self.execution.execute_place(mock_order_package, mock_session)
+        mock__execution_helper.assert_called_with(
+            mock_place, mock_order_package, mock_session
+        )
+        mock__order_logger.assert_called_with(
+            mock_order, mock_instruction_report, OrderPackageType.PLACE
+        )
+        mock_order.executable.assert_not_called()
         mock_order.trade.__enter__.assert_called_with()
         mock_order.trade.__exit__.assert_called_with(None, None, None)
         mock_order_package.client.add_transaction.assert_called_with(1)

--- a/tests/test_markets.py
+++ b/tests/test_markets.py
@@ -141,7 +141,7 @@ class MarketTest(unittest.TestCase):
     def test_transaction(self, mock_transaction):
         transaction = self.market.transaction()
         mock_transaction.assert_called_with(
-            self.market, id_=self.market._transaction_id
+            self.market, id_=self.market._transaction_id, async_place_orders=False
         )
         self.assertEqual(transaction, mock_transaction())
 

--- a/tests/test_order.py
+++ b/tests/test_order.py
@@ -285,6 +285,7 @@ class BetfairOrderTest(unittest.TestCase):
     @mock.patch("flumine.order.order.BetfairOrder.cancelling")
     def test_cancel(self, mock_cancelling, mock_size_remaining):
         mock_size_remaining.return_value = 20
+        self.order.bet_id = 123
         self.order.status = OrderStatus.EXECUTABLE
         with self.assertRaises(OrderUpdateError):
             self.order.cancel(12)
@@ -295,6 +296,11 @@ class BetfairOrderTest(unittest.TestCase):
         mock_cancelling.assert_called_with()
         self.order.cancel()
         self.assertEqual(self.order.update_data, {"size_reduction": None})
+
+    def test_cancel_bet_id(self):
+        self.order.status = OrderStatus.EXECUTABLE
+        with self.assertRaises(OrderUpdateError):
+            self.order.cancel(12)
 
     @mock.patch(
         "flumine.order.order.BetfairOrder.size_remaining",
@@ -324,6 +330,7 @@ class BetfairOrderTest(unittest.TestCase):
 
     @mock.patch("flumine.order.order.BetfairOrder.updating")
     def test_update(self, mock_updating):
+        self.order.bet_id = 123
         self.order.status = OrderStatus.EXECUTABLE
         with self.assertRaises(OrderUpdateError):
             self.order.update("PERSIST")
@@ -337,6 +344,11 @@ class BetfairOrderTest(unittest.TestCase):
         with self.assertRaises(OrderUpdateError):
             self.order.update("PERSIST")
 
+    def test_update_bet_id(self):
+        self.order.status = OrderStatus.EXECUTABLE
+        with self.assertRaises(OrderUpdateError):
+            self.order.update("PERSIST")
+
     def test_update_error(self):
         self.mock_order_type.ORDER_TYPE = OrderTypes.LIMIT
         self.mock_order_type.persistence_type = "LAPSE"
@@ -346,6 +358,7 @@ class BetfairOrderTest(unittest.TestCase):
 
     @mock.patch("flumine.order.order.BetfairOrder.replacing")
     def test_replace(self, mock_replacing):
+        self.order.bet_id = 123
         self.order.status = OrderStatus.EXECUTABLE
         with self.assertRaises(OrderUpdateError):
             self.order.replace(1.01)
@@ -358,6 +371,11 @@ class BetfairOrderTest(unittest.TestCase):
 
         with self.assertRaises(OrderUpdateError):
             self.order.replace(2.02)
+
+    def test_replace_bet_id(self):
+        self.order.status = OrderStatus.EXECUTABLE
+        with self.assertRaises(OrderUpdateError):
+            self.order.replace(1.01)
 
     def test_replace_error(self):
         self.mock_order_type.ORDER_TYPE = OrderTypes.LIMIT

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -29,6 +29,7 @@ class BaseOrderTest(unittest.TestCase):
         config.simulated = False
 
     def test_process_current_orders_with_default_sep(self):
+        mock_log_control = mock.Mock()
         market_book = mock.Mock()
         markets = Markets()
         market = Market(
@@ -54,7 +55,12 @@ class BaseOrderTest(unittest.TestCase):
 
         event = mock.Mock(event=[mock.Mock(orders=[current_order])])
 
-        process_current_orders(markets=markets, strategies=strategies, event=event)
+        process_current_orders(
+            markets=markets,
+            strategies=strategies,
+            event=event,
+            log_control=mock_log_control,
+        )
 
         self.assertEqual(current_order, betfair_order.responses.current_order)
 

--- a/tests/test_transaction.py
+++ b/tests/test_transaction.py
@@ -168,7 +168,7 @@ class TransactionTest(unittest.TestCase):
         self.assertEqual(self.transaction.execute(), 4)
         mock__create_order_package.assert_has_calls(
             [
-                call([(mock_order, 1234)], OrderPackageType.PLACE),
+                call([(mock_order, 1234)], OrderPackageType.PLACE, async_=True),
                 call([(mock_order, None)], OrderPackageType.CANCEL),
                 call([(mock_order, None)], OrderPackageType.UPDATE),
                 call([(mock_order, 1234)], OrderPackageType.REPLACE),
@@ -226,6 +226,7 @@ class TransactionTest(unittest.TestCase):
                     package_type=OrderPackageType.PLACE,
                     bet_delay=self.transaction.market.market_book.bet_delay,
                     market_version=None,
+                    async_=False,
                 ),
                 call(
                     client=self.transaction.market.flumine.client,
@@ -234,6 +235,7 @@ class TransactionTest(unittest.TestCase):
                     package_type=OrderPackageType.PLACE,
                     bet_delay=self.transaction.market.market_book.bet_delay,
                     market_version=123,
+                    async_=False,
                 ),
                 call(
                     client=self.transaction.market.flumine.client,
@@ -242,6 +244,7 @@ class TransactionTest(unittest.TestCase):
                     package_type=OrderPackageType.PLACE,
                     bet_delay=self.transaction.market.market_book.bet_delay,
                     market_version=123,
+                    async_=False,
                 ),
             ]
         )

--- a/tests/test_transaction.py
+++ b/tests/test_transaction.py
@@ -10,11 +10,12 @@ class TransactionTest(unittest.TestCase):
     def setUp(self) -> None:
         mock_blotter = {}
         self.mock_market = mock.Mock(blotter=mock_blotter)
-        self.transaction = Transaction(self.mock_market, 1)
+        self.transaction = Transaction(self.mock_market, 1, False)
 
     def test_init(self):
         self.assertEqual(self.transaction.market, self.mock_market)
         self.assertEqual(self.transaction._id, 1)
+        self.assertFalse(self.transaction._async_place_orders)
         self.assertFalse(self.transaction._pending_orders)
         self.assertEqual(self.transaction._pending_place, [])
         self.assertEqual(self.transaction._pending_cancel, [])
@@ -160,6 +161,37 @@ class TransactionTest(unittest.TestCase):
     @mock.patch("flumine.execution.transaction.Transaction._create_order_package")
     def test_execute(self, mock__create_order_package):
         self.transaction._pending_orders = True
+        mock_package = mock.Mock()
+        mock__create_order_package.return_value = [mock_package]
+        self.assertEqual(self.transaction.execute(), 0)
+        mock_order = mock.Mock()
+        self.transaction._pending_place = [(mock_order, 1234)]
+        self.transaction._pending_cancel = [(mock_order, None)]
+        self.transaction._pending_update = [(mock_order, None)]
+        self.transaction._pending_replace = [(mock_order, 1234)]
+        self.assertEqual(self.transaction.execute(), 4)
+        mock__create_order_package.assert_has_calls(
+            [
+                call([(mock_order, 1234)], OrderPackageType.PLACE, async_=False),
+                call([(mock_order, None)], OrderPackageType.CANCEL),
+                call([(mock_order, None)], OrderPackageType.UPDATE),
+                call([(mock_order, 1234)], OrderPackageType.REPLACE),
+            ]
+        )
+        self.transaction.market.flumine.process_order_package.assert_has_calls(
+            [
+                call(mock__create_order_package()[0]),
+                call(mock__create_order_package()[0]),
+                call(mock__create_order_package()[0]),
+                call(mock__create_order_package()[0]),
+            ]
+        )
+        self.assertFalse(self.transaction._pending_orders)
+
+    @mock.patch("flumine.execution.transaction.Transaction._create_order_package")
+    def test_execute_async(self, mock__create_order_package):
+        self.transaction._pending_orders = True
+        self.transaction._async_place_orders = True
         mock_package = mock.Mock()
         mock__create_order_package.return_value = [mock_package]
         self.assertEqual(self.transaction.execute(), 0)


### PR DESCRIPTION
… quicker when waiting for bet delay

error handling on order cancel/update/replace when betId not yet present
handling to add betId when received through stream / log through logging_control