### PR TITLE
prevent closure functions being called on a recorder closure (dict no…

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,18 @@
 Release History
 ---------------
 
+1.17.8 (2021-03-08)
++++++++++++++++++++
+
+**Improvements**
+
+- Allow kwargs to be passed to `trade.create_order`
+- Correct handling off completed offset orderrs
+
+**Bug Fixes**
+
+- Prevent closure functions being called on a recorder closure
+
 1.17.7 (2021-03-05)
 +++++++++++++++++++
 

--- a/flumine/__version__.py
+++ b/flumine/__version__.py
@@ -1,6 +1,6 @@
 __title__ = "flumine"
 __description__ = "Betfair trading framework"
 __url__ = "https://github.com/liampauling/flumine"
-__version__ = "1.17.7"
+__version__ = "1.17.8"
 __author__ = "Liam Pauling"
 __license__ = "MIT"

--- a/tests/test_baseflumine.py
+++ b/tests/test_baseflumine.py
@@ -225,14 +225,11 @@ class BaseFlumineTest(unittest.TestCase):
         mock_event.event = mock_market_book
         self.base_flumine._process_close_market(mock_event)
         mock_market.close_market.assert_called_with()
-        mock_market.blotter.process_closed_market.assert_called_with(mock_market_book)
+        mock_market.blotter.process_closed_market.assert_not_called()
         mock_strategy.process_closed_market.assert_called_with(
             mock_market, mock_market_book
         )
         mock_log_control.assert_called_with(mock_event)
-        self.assertEqual(
-            self.base_flumine.cleared_market_queue.get(), mock_market_book["id"]
-        )
 
     @mock.patch("flumine.baseflumine.BaseFlumine.info")
     def test__process_close_market_no_market(self, mock_info):

--- a/tests/test_trade.py
+++ b/tests/test_trade.py
@@ -72,8 +72,10 @@ class TradeTest(unittest.TestCase):
         self.assertFalse(self.trade.complete)
 
     def test_trade_complete_offset(self):
-        self.trade.offset_orders = [1]
+        self.trade.offset_orders = [mock.Mock(complete=False)]
         self.assertFalse(self.trade.complete)
+        self.trade.offset_orders = [mock.Mock(complete=True)]
+        self.assertTrue(self.trade.complete)
 
     def test_trade_complete_replace_order(self):
         self.assertTrue(self.trade.complete)
@@ -87,7 +89,16 @@ class TradeTest(unittest.TestCase):
         mock_order_type.EXCHANGE = "SYM"
         mock_order = mock.Mock()
         mock_order.EXCHANGE = "SYM"
-        self.trade.create_order("BACK", mock_order_type, handicap=1, order=mock_order)
+        self.trade.create_order(
+            "BACK", mock_order_type, handicap=1, order=mock_order, context={1: 2}
+        )
+        mock_order.assert_called_with(
+            trade=self.trade,
+            side="BACK",
+            order_type=mock_order_type,
+            handicap=1,
+            context={1: 2},
+        )
         self.assertEqual(self.trade.orders, [mock_order()])
 
     def test_create_order_error(self):
@@ -151,6 +162,7 @@ class TradeTest(unittest.TestCase):
             {
                 "id": str(self.trade.id),
                 "orders": [],
+                "offset_orders": [],
                 "place_reset_seconds": 12,
                 "reset_seconds": 34,
                 "strategy": str(self.mock_strategy),


### PR DESCRIPTION
…t objects)

reorder process so closure called after market is added