### PR TITLE
Refactoring out the get_worst_possible_profit method

### DIFF
--- a/flumine/controls/tradingcontrols.py
+++ b/flumine/controls/tradingcontrols.py
@@ -156,13 +156,13 @@ class StrategyExposure(BaseControl):
             Exposure refers to the largest potential loss.
             """
             if order.side == "BACK":
-                current_selection_exposure = -min(
-                    current_exposures["worst_possible_profit_on_lose"], 0
-                )
+                current_selection_exposure = -current_exposures[
+                    "worst_possible_profit_on_lose"
+                ]
             else:
-                current_selection_exposure = -min(
-                    current_exposures["worst_possible_profit_on_win"], 0
-                )
+                current_selection_exposure = -current_exposures[
+                    "worst_possible_profit_on_win"
+                ]
             potential_exposure = current_selection_exposure + order_exposure
             if potential_exposure > strategy.max_selection_exposure:
                 return self._on_error(

--- a/flumine/markets/blotter.py
+++ b/flumine/markets/blotter.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Iterable
+from typing import Iterable, Tuple
 from collections import defaultdict
 
 from ..order.ordertype import OrderTypes
@@ -77,6 +77,15 @@ class Blotter:
             positive = potential loss
             zero = no potential loss
         """
+        (
+            worst_possible_profit_on_win,
+            worst_possible_profit_on_lose,
+        ) = self.get_worst_possible_profit(strategy=strategy, lookup=lookup)
+        exposure = -min(worst_possible_profit_on_win, worst_possible_profit_on_lose)
+        return max(exposure, 0.0)
+
+    def get_worst_possible_profit(self, strategy, lookup: tuple) -> Tuple:
+        """Returns strategy/selection worst-case profit for win and loss outcomes separately."""
         mb, ml = [], []  # matched bets, (price, size)
         ub, ul = [], []  # unmatched bets, (price, size)
         moc_win_liability = 0.0
@@ -118,8 +127,7 @@ class Blotter:
         worst_possible_profit_on_lose = (
             matched_exposure[1] + unmatched_exposure[1] + moc_lose_liability
         )
-        exposure = -min(worst_possible_profit_on_win, worst_possible_profit_on_lose)
-        return max(exposure, 0.0)
+        return worst_possible_profit_on_win, worst_possible_profit_on_lose
 
     """ getters / setters """
 

--- a/flumine/markets/blotter.py
+++ b/flumine/markets/blotter.py
@@ -132,7 +132,7 @@ class Blotter:
             "matched_profit_if_win": matched_exposure[0],
             "matched_profit_if_lose": matched_exposure[1],
             "worst_potential_unmatched_profit_if_win": unmatched_exposure[0],
-            "worst_potential_unmatched_profit_if_lose": unmatched_exposure[0],
+            "worst_potential_unmatched_profit_if_lose": unmatched_exposure[1],
             "worst_possible_profit_on_win": worst_possible_profit_on_win,
             "worst_possible_profit_on_lose": worst_possible_profit_on_lose,
         }

--- a/flumine/markets/blotter.py
+++ b/flumine/markets/blotter.py
@@ -77,15 +77,15 @@ class Blotter:
             positive = potential loss
             zero = no potential loss
         """
-        (
-            worst_possible_profit_on_win,
-            worst_possible_profit_on_lose,
-        ) = self.get_worst_possible_profit(strategy=strategy, lookup=lookup)
-        exposure = -min(worst_possible_profit_on_win, worst_possible_profit_on_lose)
+        exposures = self.get_exposures(strategy=strategy, lookup=lookup)
+        exposure = -min(
+            exposures["worst_possible_profit_on_win"],
+            exposures["worst_possible_profit_on_lose"],
+        )
         return max(exposure, 0.0)
 
-    def get_worst_possible_profit(self, strategy, lookup: tuple) -> Tuple:
-        """Returns strategy/selection worst-case profit for win and loss outcomes separately."""
+    def get_exposures(self, strategy, lookup: tuple) -> dict:
+        """Returns strategy/selection exposures as a dict."""
         mb, ml = [], []  # matched bets, (price, size)
         ub, ul = [], []  # unmatched bets, (price, size)
         moc_win_liability = 0.0
@@ -127,7 +127,15 @@ class Blotter:
         worst_possible_profit_on_lose = (
             matched_exposure[1] + unmatched_exposure[1] + moc_lose_liability
         )
-        return worst_possible_profit_on_win, worst_possible_profit_on_lose
+
+        return {
+            "matched_profit_if_win": matched_exposure[0],
+            "matched_profit_if_lose": matched_exposure[1],
+            "worst_potential_unmatched_profit_if_win": unmatched_exposure[0],
+            "worst_potential_unmatched_profit_if_lose": unmatched_exposure[0],
+            "worst_possible_profit_on_win": worst_possible_profit_on_win,
+            "worst_possible_profit_on_lose": worst_possible_profit_on_lose,
+        }
 
     """ getters / setters """
 

--- a/tests/test_blotter.py
+++ b/tests/test_blotter.py
@@ -55,7 +55,7 @@ class BlotterTest(unittest.TestCase):
         mock_cleared_orders = mock.Mock()
         self.assertEqual(self.blotter.process_cleared_orders(mock_cleared_orders), [])
 
-    def test_selection_exposure(self):
+    def test_get_exposures(self):
         mock_strategy = mock.Mock()
         mock_trade = mock.Mock(strategy=mock_strategy)
         mock_order = mock.Mock(
@@ -69,11 +69,18 @@ class BlotterTest(unittest.TestCase):
         )
         self.blotter["12345"] = mock_order
         self.assertEqual(
-            self.blotter.selection_exposure(mock_strategy, mock_order.lookup),
-            2.0,
+            self.blotter.get_exposures(mock_strategy, mock_order.lookup),
+            {
+                'matched_profit_if_lose': -2.0,
+                'matched_profit_if_win': 9.2,
+                'worst_possible_profit_on_lose': -2.0,
+                'worst_possible_profit_on_win': 9.2,
+                'worst_potential_unmatched_profit_if_lose': 0.0,
+                'worst_potential_unmatched_profit_if_win': 0.0
+            }
         )
 
-    def test_selection_exposure_raises_value_error(self):
+    def test_get_exposures_value_error(self):
         mock_strategy = mock.Mock()
         mock_trade = mock.Mock(strategy=mock_strategy)
         mock_order = mock.Mock(
@@ -88,16 +95,15 @@ class BlotterTest(unittest.TestCase):
         self.blotter["12345"] = mock_order
 
         with self.assertRaises(ValueError) as e:
-            self.blotter.selection_exposure(mock_strategy, mock_order.lookup)
+            self.blotter.get_exposures(mock_strategy, mock_order.lookup)
 
         self.assertEqual("Unexpected order type: INVALID", e.exception.args[0])
 
-    def test_selection_exposure_with_price_none(self):
+    def test_get_exposures_with_price_none(self):
         """
-        Check that selection_exposure works if order.order_type.price is None.
+        Check that get_exposures works if order.order_type.price is None.
         If order.order_type.price is None, the controls will flag the order as a violation
         and it won't be set to the exchange, so there won't be any exposure and we can ignore it.
-        :return:
         """
         mock_strategy = mock.Mock()
         mock_trade = mock.Mock(strategy=mock_strategy)
@@ -123,11 +129,18 @@ class BlotterTest(unittest.TestCase):
         self.blotter["12345"] = mock_order1
         self.blotter["23456"] = mock_order2
         self.assertEqual(
-            self.blotter.selection_exposure(mock_strategy, lookup),
-            2.0,
+            self.blotter.get_exposures(mock_strategy, lookup),
+            {
+                'matched_profit_if_lose': -2.0,
+                'matched_profit_if_win': 9.2,
+                'worst_possible_profit_on_lose': -2.0,
+                'worst_possible_profit_on_win': 9.2,
+                'worst_potential_unmatched_profit_if_lose': 0.0,
+                'worst_potential_unmatched_profit_if_win': 0.0
+            },
         )
 
-    def test_selection_exposure_no_match(self):
+    def test_get_exposures_no_match(self):
         mock_strategy = mock.Mock()
         mock_trade = mock.Mock(strategy=mock_strategy)
         mock_order = mock.Mock(
@@ -141,11 +154,18 @@ class BlotterTest(unittest.TestCase):
         )
         self.blotter["12345"] = mock_order
         self.assertEqual(
-            self.blotter.selection_exposure(mock_strategy, mock_order.lookup),
-            0.0,
+            self.blotter.get_exposures(mock_strategy, mock_order.lookup),
+            {
+                'matched_profit_if_lose': 0.0,
+                'matched_profit_if_win': 0.0,
+                'worst_possible_profit_on_lose': 0.0,
+                'worst_possible_profit_on_win': 0.0,
+                'worst_potential_unmatched_profit_if_lose': 0.0,
+                'worst_potential_unmatched_profit_if_win': 0.0
+            },
         )
 
-    def test_selection_exposure_from_unmatched_back(self):
+    def test_get_exposures_from_unmatched_back(self):
         mock_strategy = mock.Mock()
         mock_trade = mock.Mock(strategy=mock_strategy)
         mock_order = mock.Mock(
@@ -161,11 +181,18 @@ class BlotterTest(unittest.TestCase):
         # On the win side, we have 2.0 * (5.6-1.0) = 9.2
         # On the lose side, we have -2.0-2.0=-4.0
         self.assertEqual(
-            self.blotter.selection_exposure(mock_strategy, mock_order.lookup),
-            4.0,
+            self.blotter.get_exposures(mock_strategy, mock_order.lookup),
+            {
+                'matched_profit_if_lose': -2.0,
+                'matched_profit_if_win': 9.2,
+                'worst_possible_profit_on_lose': -4.0,
+                'worst_possible_profit_on_win': 9.2,
+                'worst_potential_unmatched_profit_if_lose': -2.0,
+                'worst_potential_unmatched_profit_if_win': 0
+            },
         )
 
-    def test_selection_exposure_from_unmatched_lay(self):
+    def test_get_exposures_from_unmatched_lay(self):
         mock_strategy = mock.Mock()
         mock_trade = mock.Mock(strategy=mock_strategy)
         mock_order = mock.Mock(
@@ -181,11 +208,18 @@ class BlotterTest(unittest.TestCase):
         # On the win side, we have -2.0 * (5.6-1.0) -2.0 * (6.0-1.0) = -19.2
         # On the lose side, we have 2.0 from size_matched
         self.assertEqual(
-            self.blotter.selection_exposure(mock_strategy, mock_order.lookup),
-            19.2,
+            self.blotter.get_exposures(mock_strategy, mock_order.lookup),
+            {
+                'matched_profit_if_lose': 2.0,
+                'matched_profit_if_win': -9.2,
+                'worst_possible_profit_on_lose': 2.0,
+                'worst_possible_profit_on_win': -19.2,
+                'worst_potential_unmatched_profit_if_lose': 0,
+                'worst_potential_unmatched_profit_if_win': -10.0
+            },
         )
 
-    def test_selection_exposure_from_market_on_close_back(self):
+    def test_get_exposures_from_market_on_close_back(self):
         mock_strategy = mock.Mock()
         mock_trade = mock.Mock(strategy=mock_strategy)
         mock_order = mock.Mock(
@@ -196,11 +230,18 @@ class BlotterTest(unittest.TestCase):
         )
         self.blotter["12345"] = mock_order
         self.assertEqual(
-            self.blotter.selection_exposure(mock_strategy, mock_order.lookup),
-            10.0,
+            self.blotter.get_exposures(mock_strategy, mock_order.lookup),
+            {
+                'matched_profit_if_lose': 0.0,
+                'matched_profit_if_win': 0.0,
+                'worst_possible_profit_on_lose': -10.0,
+                'worst_possible_profit_on_win': 0.0,
+                'worst_potential_unmatched_profit_if_lose': 0.0,
+                'worst_potential_unmatched_profit_if_win': 0.0
+            },
         )
 
-    def test_selection_exposure_from_market_on_close_lay(self):
+    def test_get_exposures_from_market_on_close_lay(self):
         mock_strategy = mock.Mock()
         mock_trade = mock.Mock(strategy=mock_strategy)
         mock_order = mock.Mock(
@@ -211,11 +252,18 @@ class BlotterTest(unittest.TestCase):
         )
         self.blotter["12345"] = mock_order
         self.assertEqual(
-            self.blotter.selection_exposure(mock_strategy, mock_order.lookup),
-            10.0,
+            self.blotter.get_exposures(mock_strategy, mock_order.lookup),
+            {
+                'matched_profit_if_lose': 0.0,
+                'matched_profit_if_win': 0.0,
+                'worst_possible_profit_on_lose': 0.0,
+                'worst_possible_profit_on_win': -10.0,
+                'worst_potential_unmatched_profit_if_lose': 0.0,
+                'worst_potential_unmatched_profit_if_win': 0.0
+            },
         )
 
-    def test_selection_exposure_from_limit_on_close_lay(self):
+    def test_get_exposures_from_limit_on_close_lay(self):
         mock_strategy = mock.Mock()
         mock_trade = mock.Mock(strategy=mock_strategy)
         mock_order = mock.Mock(
@@ -226,11 +274,18 @@ class BlotterTest(unittest.TestCase):
         )
         self.blotter["12345"] = mock_order
         self.assertEqual(
-            self.blotter.selection_exposure(mock_strategy, mock_order.lookup),
-            10.0,
+            self.blotter.get_exposures(mock_strategy, mock_order.lookup),
+            {
+                'matched_profit_if_lose': 0.0,
+                'matched_profit_if_win': 0.0,
+                'worst_possible_profit_on_lose': 0.0,
+                'worst_possible_profit_on_win': -10.0,
+                'worst_potential_unmatched_profit_if_lose': 0.0,
+                'worst_potential_unmatched_profit_if_win': 0.0
+            },
         )
 
-    def test_selection_exposure_voided(self):
+    def test_get_exposures_voided(self):
         mock_strategy = mock.Mock()
         mock_trade = mock.Mock(strategy=mock_strategy)
         mock_order = mock.Mock(
@@ -242,8 +297,16 @@ class BlotterTest(unittest.TestCase):
         )
         self.blotter["12345"] = mock_order
         self.assertEqual(
-            self.blotter.selection_exposure(mock_strategy, mock_order.lookup),
-            0,
+            self.blotter.get_exposures(mock_strategy, mock_order.lookup),
+            {
+                'matched_profit_if_lose': 0.0,
+                'matched_profit_if_win': 0.0,
+                'worst_possible_profit_on_lose': 0.0,
+                'worst_possible_profit_on_win': 0.0,
+                'worst_potential_unmatched_profit_if_lose': 0.0,
+                'worst_potential_unmatched_profit_if_win': 0.0
+            }
+            ,
         )
 
     def test_complete_order(self):

--- a/tests/test_blotter.py
+++ b/tests/test_blotter.py
@@ -55,6 +55,38 @@ class BlotterTest(unittest.TestCase):
         mock_cleared_orders = mock.Mock()
         self.assertEqual(self.blotter.process_cleared_orders(mock_cleared_orders), [])
 
+    def test_selection_exposure(self):
+        """
+        Check that selection_exposure returns the absolute worse loss
+        """
+        def get_exposures(strategy, lookup):
+            if strategy=="strategy" and lookup==(1,2,3):
+                return {
+                    'worst_possible_profit_on_win': -1.0,
+                    'worst_possible_profit_on_lose': -2.0,
+                }
+        self.blotter.get_exposures = mock.Mock(side_effect=get_exposures)
+
+        result = self.blotter.selection_exposure("strategy", (1, 2, 3))
+
+        self.assertEqual(2.0, result)
+
+    def test_selection_exposure2(self):
+        """
+        Check that selection_exposure returns zero if there is no risk of loss.
+        """
+        def get_exposures(strategy, lookup):
+            if strategy=="strategy" and lookup==(1,2,3):
+                return {
+                    'worst_possible_profit_on_win': 0.0,
+                    'worst_possible_profit_on_lose': 1.0,
+                }
+        self.blotter.get_exposures = mock.Mock(side_effect=get_exposures)
+
+        result = self.blotter.selection_exposure("strategy", (1, 2, 3))
+
+        self.assertEqual(0.0, result)
+
     def test_get_exposures(self):
         mock_strategy = mock.Mock()
         mock_trade = mock.Mock(strategy=mock_strategy)

--- a/tests/test_blotter.py
+++ b/tests/test_blotter.py
@@ -59,12 +59,14 @@ class BlotterTest(unittest.TestCase):
         """
         Check that selection_exposure returns the absolute worse loss
         """
+
         def get_exposures(strategy, lookup):
-            if strategy=="strategy" and lookup==(1,2,3):
+            if strategy == "strategy" and lookup == (1, 2, 3):
                 return {
-                    'worst_possible_profit_on_win': -1.0,
-                    'worst_possible_profit_on_lose': -2.0,
+                    "worst_possible_profit_on_win": -1.0,
+                    "worst_possible_profit_on_lose": -2.0,
                 }
+
         self.blotter.get_exposures = mock.Mock(side_effect=get_exposures)
 
         result = self.blotter.selection_exposure("strategy", (1, 2, 3))
@@ -75,12 +77,14 @@ class BlotterTest(unittest.TestCase):
         """
         Check that selection_exposure returns zero if there is no risk of loss.
         """
+
         def get_exposures(strategy, lookup):
-            if strategy=="strategy" and lookup==(1,2,3):
+            if strategy == "strategy" and lookup == (1, 2, 3):
                 return {
-                    'worst_possible_profit_on_win': 0.0,
-                    'worst_possible_profit_on_lose': 1.0,
+                    "worst_possible_profit_on_win": 0.0,
+                    "worst_possible_profit_on_lose": 1.0,
                 }
+
         self.blotter.get_exposures = mock.Mock(side_effect=get_exposures)
 
         result = self.blotter.selection_exposure("strategy", (1, 2, 3))
@@ -103,13 +107,13 @@ class BlotterTest(unittest.TestCase):
         self.assertEqual(
             self.blotter.get_exposures(mock_strategy, mock_order.lookup),
             {
-                'matched_profit_if_lose': -2.0,
-                'matched_profit_if_win': 9.2,
-                'worst_possible_profit_on_lose': -2.0,
-                'worst_possible_profit_on_win': 9.2,
-                'worst_potential_unmatched_profit_if_lose': 0.0,
-                'worst_potential_unmatched_profit_if_win': 0.0
-            }
+                "matched_profit_if_lose": -2.0,
+                "matched_profit_if_win": 9.2,
+                "worst_possible_profit_on_lose": -2.0,
+                "worst_possible_profit_on_win": 9.2,
+                "worst_potential_unmatched_profit_if_lose": 0.0,
+                "worst_potential_unmatched_profit_if_win": 0.0,
+            },
         )
 
     def test_get_exposures_value_error(self):
@@ -163,12 +167,12 @@ class BlotterTest(unittest.TestCase):
         self.assertEqual(
             self.blotter.get_exposures(mock_strategy, lookup),
             {
-                'matched_profit_if_lose': -2.0,
-                'matched_profit_if_win': 9.2,
-                'worst_possible_profit_on_lose': -2.0,
-                'worst_possible_profit_on_win': 9.2,
-                'worst_potential_unmatched_profit_if_lose': 0.0,
-                'worst_potential_unmatched_profit_if_win': 0.0
+                "matched_profit_if_lose": -2.0,
+                "matched_profit_if_win": 9.2,
+                "worst_possible_profit_on_lose": -2.0,
+                "worst_possible_profit_on_win": 9.2,
+                "worst_potential_unmatched_profit_if_lose": 0.0,
+                "worst_potential_unmatched_profit_if_win": 0.0,
             },
         )
 
@@ -188,12 +192,12 @@ class BlotterTest(unittest.TestCase):
         self.assertEqual(
             self.blotter.get_exposures(mock_strategy, mock_order.lookup),
             {
-                'matched_profit_if_lose': 0.0,
-                'matched_profit_if_win': 0.0,
-                'worst_possible_profit_on_lose': 0.0,
-                'worst_possible_profit_on_win': 0.0,
-                'worst_potential_unmatched_profit_if_lose': 0.0,
-                'worst_potential_unmatched_profit_if_win': 0.0
+                "matched_profit_if_lose": 0.0,
+                "matched_profit_if_win": 0.0,
+                "worst_possible_profit_on_lose": 0.0,
+                "worst_possible_profit_on_win": 0.0,
+                "worst_potential_unmatched_profit_if_lose": 0.0,
+                "worst_potential_unmatched_profit_if_win": 0.0,
             },
         )
 
@@ -215,12 +219,12 @@ class BlotterTest(unittest.TestCase):
         self.assertEqual(
             self.blotter.get_exposures(mock_strategy, mock_order.lookup),
             {
-                'matched_profit_if_lose': -2.0,
-                'matched_profit_if_win': 9.2,
-                'worst_possible_profit_on_lose': -4.0,
-                'worst_possible_profit_on_win': 9.2,
-                'worst_potential_unmatched_profit_if_lose': -2.0,
-                'worst_potential_unmatched_profit_if_win': 0
+                "matched_profit_if_lose": -2.0,
+                "matched_profit_if_win": 9.2,
+                "worst_possible_profit_on_lose": -4.0,
+                "worst_possible_profit_on_win": 9.2,
+                "worst_potential_unmatched_profit_if_lose": -2.0,
+                "worst_potential_unmatched_profit_if_win": 0,
             },
         )
 
@@ -242,12 +246,12 @@ class BlotterTest(unittest.TestCase):
         self.assertEqual(
             self.blotter.get_exposures(mock_strategy, mock_order.lookup),
             {
-                'matched_profit_if_lose': 2.0,
-                'matched_profit_if_win': -9.2,
-                'worst_possible_profit_on_lose': 2.0,
-                'worst_possible_profit_on_win': -19.2,
-                'worst_potential_unmatched_profit_if_lose': 0,
-                'worst_potential_unmatched_profit_if_win': -10.0
+                "matched_profit_if_lose": 2.0,
+                "matched_profit_if_win": -9.2,
+                "worst_possible_profit_on_lose": 2.0,
+                "worst_possible_profit_on_win": -19.2,
+                "worst_potential_unmatched_profit_if_lose": 0,
+                "worst_potential_unmatched_profit_if_win": -10.0,
             },
         )
 
@@ -264,12 +268,12 @@ class BlotterTest(unittest.TestCase):
         self.assertEqual(
             self.blotter.get_exposures(mock_strategy, mock_order.lookup),
             {
-                'matched_profit_if_lose': 0.0,
-                'matched_profit_if_win': 0.0,
-                'worst_possible_profit_on_lose': -10.0,
-                'worst_possible_profit_on_win': 0.0,
-                'worst_potential_unmatched_profit_if_lose': 0.0,
-                'worst_potential_unmatched_profit_if_win': 0.0
+                "matched_profit_if_lose": 0.0,
+                "matched_profit_if_win": 0.0,
+                "worst_possible_profit_on_lose": -10.0,
+                "worst_possible_profit_on_win": 0.0,
+                "worst_potential_unmatched_profit_if_lose": 0.0,
+                "worst_potential_unmatched_profit_if_win": 0.0,
             },
         )
 
@@ -286,12 +290,12 @@ class BlotterTest(unittest.TestCase):
         self.assertEqual(
             self.blotter.get_exposures(mock_strategy, mock_order.lookup),
             {
-                'matched_profit_if_lose': 0.0,
-                'matched_profit_if_win': 0.0,
-                'worst_possible_profit_on_lose': 0.0,
-                'worst_possible_profit_on_win': -10.0,
-                'worst_potential_unmatched_profit_if_lose': 0.0,
-                'worst_potential_unmatched_profit_if_win': 0.0
+                "matched_profit_if_lose": 0.0,
+                "matched_profit_if_win": 0.0,
+                "worst_possible_profit_on_lose": 0.0,
+                "worst_possible_profit_on_win": -10.0,
+                "worst_potential_unmatched_profit_if_lose": 0.0,
+                "worst_potential_unmatched_profit_if_win": 0.0,
             },
         )
 
@@ -308,12 +312,12 @@ class BlotterTest(unittest.TestCase):
         self.assertEqual(
             self.blotter.get_exposures(mock_strategy, mock_order.lookup),
             {
-                'matched_profit_if_lose': 0.0,
-                'matched_profit_if_win': 0.0,
-                'worst_possible_profit_on_lose': 0.0,
-                'worst_possible_profit_on_win': -10.0,
-                'worst_potential_unmatched_profit_if_lose': 0.0,
-                'worst_potential_unmatched_profit_if_win': 0.0
+                "matched_profit_if_lose": 0.0,
+                "matched_profit_if_win": 0.0,
+                "worst_possible_profit_on_lose": 0.0,
+                "worst_possible_profit_on_win": -10.0,
+                "worst_potential_unmatched_profit_if_lose": 0.0,
+                "worst_potential_unmatched_profit_if_win": 0.0,
             },
         )
 
@@ -331,14 +335,13 @@ class BlotterTest(unittest.TestCase):
         self.assertEqual(
             self.blotter.get_exposures(mock_strategy, mock_order.lookup),
             {
-                'matched_profit_if_lose': 0.0,
-                'matched_profit_if_win': 0.0,
-                'worst_possible_profit_on_lose': 0.0,
-                'worst_possible_profit_on_win': 0.0,
-                'worst_potential_unmatched_profit_if_lose': 0.0,
-                'worst_potential_unmatched_profit_if_win': 0.0
-            }
-            ,
+                "matched_profit_if_lose": 0.0,
+                "matched_profit_if_win": 0.0,
+                "worst_possible_profit_on_lose": 0.0,
+                "worst_possible_profit_on_win": 0.0,
+                "worst_potential_unmatched_profit_if_lose": 0.0,
+                "worst_potential_unmatched_profit_if_win": 0.0,
+            },
         )
 
     def test_complete_order(self):

--- a/tests/test_tradingcontrols.py
+++ b/tests/test_tradingcontrols.py
@@ -425,7 +425,9 @@ class TestStrategyExposure(unittest.TestCase):
     @mock.patch("flumine.controls.tradingcontrols.StrategyExposure._on_error")
     def test_validate_selection(self, mock_on_error):
         mock_market = mock.Mock()
-        mock_market.blotter.selection_exposure.return_value = 12.0
+        mock_market.blotter.get_exposures.return_value = {
+            "worst_possible_profit_on_win": -12.0
+        }
         self.mock_flumine.markets.markets = {"1.234": mock_market}
         mock_order = mock.Mock(market_id="1.234", lookup=(1, 2, 3), side="LAY")
         mock_order.trade.strategy.max_order_exposure = 10


### PR DESCRIPTION
I'd find the separate win/lose exposures useful when controlling risk in my strategy code.