### PR TITLE
Inplay bug

### DIFF
--- a/examples/backtest.py
+++ b/examples/backtest.py
@@ -20,12 +20,15 @@ client = clients.BacktestClient()
 framework = FlumineBacktest(client=client)
 
 _market = "tests/resources/PRO-1.170258213"
+_market = "/home/jon/data/temp/1.181212101"
 
 strategy = LowestLayer(
+    #market_filter={"markets": [_market], 'listener_kwargs' : {'inplay': False}},
     market_filter={"markets": [_market]},
     max_order_exposure=1000,
     max_selection_exposure=105,
     context={"stake": 2},
+
 )
 framework.add_strategy(strategy)
 

--- a/flumine/streams/historicalstream.py
+++ b/flumine/streams/historicalstream.py
@@ -22,6 +22,8 @@ class FlumineMarketStream(MarketStream):
     which reduces some function calls.
     """
 
+    has_sent_bsp_reconciled = False
+
     def _process(self, data: list, publish_time: int) -> bool:
         for market_book in data:
             market_id = market_book["id"]
@@ -71,7 +73,10 @@ class FlumineMarketStream(MarketStream):
                         continue
                 if self._listener.inplay is False:
                     if cache._definition_in_play:
-                        continue
+                        if cache._definition_bsp_reconciled and not self.has_sent_bsp_reconciled:
+                            self.has_sent_bsp_reconciled = True
+                        else:
+                            continue
             market_books.append(cache.create_resource(self.unique_id, snap=True))
         return market_books
 

--- a/tests/test_streams.py
+++ b/tests/test_streams.py
@@ -595,8 +595,16 @@ class TestFlumineMarketStream(unittest.TestCase):
             "1.123": mock.Mock(_definition_status="OPEN", _definition_in_play=False),
         }
         self.assertEqual(len(self.stream.snap()), 1)
+
+        # This one gets sent, as we always want to send the first bsp_reconciled
         self.stream._caches = {
-            "1.123": mock.Mock(_definition_status="OPEN", _definition_in_play=True),
+            "1.123": mock.Mock(_definition_status="OPEN", _definition_in_play=True, _definition_bsp_reconciled=True),
+        }
+        self.assertEqual(len(self.stream.snap()), 1)
+
+        # This one does not get sent, as we always want to send the first bsp_reconciled
+        self.stream._caches = {
+            "1.123": mock.Mock(_definition_status="OPEN", _definition_in_play=True, _definition_bsp_reconciled=True),
         }
         self.assertEqual(len(self.stream.snap()), 0)
 


### PR DESCRIPTION
Not really a PR, as the changes to backtest.py and InplayLayer should not be merged.

I've send you the data file via Slack.

In backtest.py, you can see the commented out line that turns on/off the inplay filter.

If you just look a the first commit, then turning the filter on/off  changes the P&L, as the single Lay order placed by LowestLayer wont' get filled if we use the inplay=False filter.

The 2nd commit contains my proposed fix.

(Apologies, but my git skills aren't sufficient to find the hashes of the 1st and 2nd commits)