### PR TITLE
refactor snap to send MarketBook when not open regardless of filter

### DIFF
--- a/flumine/streams/historicalstream.py
+++ b/flumine/streams/historicalstream.py
@@ -56,8 +56,8 @@ class FlumineMarketStream(MarketStream):
         for cache in list(self._caches.values()):
             if market_ids and cache.market_id not in market_ids:
                 continue
-            # if market has closed send regardless
-            if cache._definition_status != "CLOSED":
+            # if market is not open (closed/suspended) send regardless
+            if cache._definition_status == "OPEN":
                 if self._listener.inplay:
                     if not cache._definition_in_play:
                         continue

--- a/tests/test_streams.py
+++ b/tests/test_streams.py
@@ -609,10 +609,10 @@ class TestFlumineMarketStream(unittest.TestCase):
             "1.123": mock.Mock(
                 publish_time=123,
                 market_definition={
-                    "status": "OPEN",
-                    "inPlay": False,
                     "marketTime": 456,
                 },
+                _definition_status="OPEN",
+                _definition_in_play=False,
             )
         }
         self.assertEqual(len(self.stream.snap()), 1)
@@ -620,10 +620,10 @@ class TestFlumineMarketStream(unittest.TestCase):
             "1.123": mock.Mock(
                 publish_time=123,
                 market_definition={
-                    "status": "OPEN",
-                    "inPlay": False,
                     "marketTime": 1234567,
                 },
+                _definition_status="OPEN",
+                _definition_in_play=False,
             )
         }
         self.assertEqual(len(self.stream.snap()), 0)


### PR DESCRIPTION
instances where MoC bets where not processed correctly when inplay set to False on the listenerKwargs