### PR TITLE
Liability param decimal place check

### DIFF
--- a/flumine/controls/tradingcontrols.py
+++ b/flumine/controls/tradingcontrols.py
@@ -56,6 +56,8 @@ class OrderValidation(BaseControl):
             self._on_error(order, "Order liability is None")
         elif order.order_type.liability <= 0:
             self._on_error(order, "Order liability is less than 0")
+        elif order.order_type.liability != round(order.order_type.liability, 2):
+            self._on_error(order, "Order liability has more than 2dp")
 
     def _validate_betfair_min_size(self, order, order_type):
         client = self.flumine.client

--- a/tests/test_tradingcontrols.py
+++ b/tests/test_tradingcontrols.py
@@ -174,6 +174,13 @@ class TestOrderValidation(unittest.TestCase):
         mock_on_error.assert_called_with(order, "Order liability is less than 0")
 
     @mock.patch("flumine.controls.tradingcontrols.OrderValidation._on_error")
+    def test__validate_betfair_liability_on_error_three(self, mock_on_error):
+        order = mock.Mock()
+        order.order_type.liability = 2.999
+        self.trading_control._validate_betfair_liability(order)
+        mock_on_error.assert_called_with(order, "Order liability has more than 2dp")
+
+    @mock.patch("flumine.controls.tradingcontrols.OrderValidation._on_error")
     def test__validate_betfair_min_size_no_validation(self, mock_on_error):
         self.mock_flumine.client.min_bet_validation = False
         order = mock.Mock(side="BACK")


### PR DESCRIPTION
Check for > 2 decimal places for liability param received by order types MARKET_ON_CLOSE, LIMIT_ON_CLOSE. Addresses issue #433.