### PR TITLE
Renaming hostname to customer_strategy_ref

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,15 @@ Release History
 1.19.12 (2021-08-27)
 +++++++++++++++++++
 
+** Improvements**
+
+ - Renamed config.hostname to config.customer_strategy_ref. This makes the use of the variable more explicit.
+ - WARNING: This change will affect users who set config.hostname. From this version onwards, they should set
+            config.customer_strategy_ref.
+
+1.19.12 (2021-08-27)
++++++++++++++++++++
+
 **Bug Fixes**
 
 - Prevent duplicate EC calls when backtesting

--- a/examples/middleware/orders.py
+++ b/examples/middleware/orders.py
@@ -20,7 +20,7 @@ class OrdersMiddleware(Middleware):
 
     def add_market(self, market) -> None:
         resp = self.flumine.client.betting_client.betting.list_current_orders(
-            customer_strategy_refs=[config.hostname],
+            customer_strategy_refs=[config.customer_strategy_ref],
             order_projection="EXECUTION_COMPLETE",
         )
         for current_order in resp.orders:

--- a/flumine/config.py
+++ b/flumine/config.py
@@ -9,6 +9,8 @@ customer_strategy_ref = socket.gethostname()[
     :15
 ]  # ie. docker container id (used as order customerStrategyRefs)
 
+hostname = customer_strategy_ref
+
 process_id = os.getpid()  # process id of app
 
 current_time = None  # used for backtesting

--- a/flumine/config.py
+++ b/flumine/config.py
@@ -5,7 +5,7 @@ simulated = False
 
 instance_id = None  # instance id (e.g. AWS ec2 instanceId)
 
-hostname = socket.gethostname()[
+customer_strategy_ref = socket.gethostname()[
     :15
 ]  # ie. docker container id (used as order customerStrategyRefs)
 

--- a/flumine/markets/market.py
+++ b/flumine/markets/market.py
@@ -181,7 +181,7 @@ class Market:
             "marketId": self.market_id,
             "eventId": self.event_id,
             "eventTypeId": self.event_type_id,
-            "customerStrategyRef": config.hostname,
+            "customerStrategyRef": config.customer_strategy_ref,
             "lastMatchedDate": None,
             "placedDate": None,
             "settledDate": None,

--- a/flumine/order/orderpackage.py
+++ b/flumine/order/orderpackage.py
@@ -45,7 +45,7 @@ class BaseOrderPackage(BaseEvent):
         self.package_type = package_type
         self.async_ = async_
         self._market_version = market_version
-        self.customer_strategy_ref = config.hostname
+        self.customer_strategy_ref = config.customer_strategy_ref
         self._retry = True
         self._max_retries = 3  # will retry 3 times
         self._retry_count = 0

--- a/flumine/streams/datastream.py
+++ b/flumine/streams/datastream.py
@@ -162,7 +162,7 @@ class OrderDataStream(DataStream):
             "Starting OrderDataStream {0}".format(self.stream_id),
             extra={
                 "stream_id": self.stream_id,
-                "customer_strategy_refs": config.hostname,
+                "customer_strategy_refs": config.customer_strategy_ref,
                 "conflate_ms": self.conflate_ms,
                 "streaming_timeout": self.streaming_timeout,
             },
@@ -173,7 +173,7 @@ class OrderDataStream(DataStream):
         try:
             self.stream_id = self._stream.subscribe_to_orders(
                 order_filter=filters.streaming_order_filter(
-                    customer_strategy_refs=[config.hostname],
+                    customer_strategy_refs=[config.customer_strategy_ref],
                     partition_matched_by_strategy_ref=True,
                     include_overall_position=False,
                 ),

--- a/flumine/streams/orderstream.py
+++ b/flumine/streams/orderstream.py
@@ -22,7 +22,7 @@ class OrderStream(BaseStream):
             "Starting OrderStream {0}".format(self.stream_id),
             extra={
                 "stream_id": self.stream_id,
-                "customer_strategy_refs": config.hostname,
+                "customer_strategy_refs": config.customer_strategy_ref,
                 "conflate_ms": self.conflate_ms,
                 "streaming_timeout": self.streaming_timeout,
             },
@@ -39,7 +39,7 @@ class OrderStream(BaseStream):
         try:
             self.stream_id = self._stream.subscribe_to_orders(
                 order_filter=filters.streaming_order_filter(
-                    customer_strategy_refs=[config.hostname],
+                    customer_strategy_refs=[config.customer_strategy_ref],
                     partition_matched_by_strategy_ref=True,
                     include_overall_position=False,
                 ),

--- a/flumine/worker.py
+++ b/flumine/worker.py
@@ -190,7 +190,7 @@ def _get_cleared_orders(flumine, betting_client, market_id: str) -> bool:
                 bet_status="SETTLED",
                 from_record=from_record,
                 market_ids=[market_id],
-                customer_strategy_refs=[config.hostname],
+                customer_strategy_refs=[config.customer_strategy_ref],
             )
         except exceptions.StatusCodeError as e:
             # log as warning to prevent duplicate logs on betfair meltdown
@@ -228,7 +228,7 @@ def _get_cleared_market(flumine, betting_client, market_id: str) -> bool:
         cleared_markets = betting_client.betting.list_cleared_orders(
             bet_status="SETTLED",
             market_ids=[market_id],
-            customer_strategy_refs=[config.hostname],
+            customer_strategy_refs=[config.customer_strategy_ref],
             group_by="MARKET",
         )
     except exceptions.StatusCodeError as e:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,7 +6,7 @@ from flumine import config
 class ConfigTest(unittest.TestCase):
     def test_init(self):
         self.assertFalse(config.simulated)
-        self.assertIsInstance(config.hostname, str)
+        self.assertIsInstance(config.customer_strategy_ref, str)
         self.assertIsInstance(config.process_id, int)
         self.assertIsNone(config.current_time)
         self.assertFalse(config.raise_errors)

--- a/tests/test_markets.py
+++ b/tests/test_markets.py
@@ -328,7 +328,7 @@ class MarketTest(unittest.TestCase):
                 "betCount": 0,
                 "betOutcome": "WON",
                 "commission": 0.0,
-                "customerStrategyRef": config.hostname,
+                "customerStrategyRef": config.customer_strategy_ref,
                 "eventId": mock_event_id,
                 "eventTypeId": mock_event_type_id,
                 "lastMatchedDate": None,

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -236,7 +236,7 @@ class WorkersTest(unittest.TestCase):
             bet_status="SETTLED",
             market_ids=["1.23"],
             from_record=0,
-            customer_strategy_refs=[mock_config.hostname],
+            customer_strategy_refs=[mock_config.customer_strategy_ref],
         )
         mock_flumine.log_control.assert_called_with(mock_events.ClearedOrdersEvent())
         mock_flumine.handler_queue.put.assert_called_with(
@@ -258,7 +258,7 @@ class WorkersTest(unittest.TestCase):
             bet_status="SETTLED",
             market_ids=["1.23"],
             from_record=0,
-            customer_strategy_refs=[mock_config.hostname],
+            customer_strategy_refs=[mock_config.customer_strategy_ref],
         )
 
     @mock.patch("flumine.worker.config")
@@ -274,7 +274,7 @@ class WorkersTest(unittest.TestCase):
             bet_status="SETTLED",
             market_ids=["1.23"],
             from_record=0,
-            customer_strategy_refs=[mock_config.hostname],
+            customer_strategy_refs=[mock_config.customer_strategy_ref],
         )
 
     @mock.patch("flumine.worker.config")
@@ -294,7 +294,7 @@ class WorkersTest(unittest.TestCase):
             bet_status="SETTLED",
             market_ids=["1.23"],
             group_by="MARKET",
-            customer_strategy_refs=[mock_config.hostname],
+            customer_strategy_refs=[mock_config.customer_strategy_ref],
         )
         mock_flumine.handler_queue.put.assert_called_with(
             mock_events.ClearedMarketsEvent()
@@ -316,7 +316,7 @@ class WorkersTest(unittest.TestCase):
             bet_status="SETTLED",
             market_ids=["1.23"],
             group_by="MARKET",
-            customer_strategy_refs=[mock_config.hostname],
+            customer_strategy_refs=[mock_config.customer_strategy_ref],
         )
 
     @mock.patch("flumine.worker.config")
@@ -334,7 +334,7 @@ class WorkersTest(unittest.TestCase):
             bet_status="SETTLED",
             market_ids=["1.23"],
             group_by="MARKET",
-            customer_strategy_refs=[mock_config.hostname],
+            customer_strategy_refs=[mock_config.customer_strategy_ref],
         )
 
     @mock.patch("flumine.worker.config")
@@ -350,5 +350,5 @@ class WorkersTest(unittest.TestCase):
             bet_status="SETTLED",
             market_ids=["1.23"],
             group_by="MARKET",
-            customer_strategy_refs=[mock_config.hostname],
+            customer_strategy_refs=[mock_config.customer_strategy_ref],
         )


### PR DESCRIPTION
Renaming `hostname` to `customer_strategy_ref`, which makes intent more explicit.