### PR TITLE
Extend selection exposures to whole market

### DIFF
--- a/docs/markets.md
+++ b/docs/markets.md
@@ -59,7 +59,7 @@ The blotter is a simple and fast class to hold all orders for a particular marke
 - `strategy_orders(strategy)` Returns all orders related to a strategy
 - `strategy_selection_orders(strategy, selection_id, handicap)` Returns all orders related to a strategy selection
 - `selection_exposure(strategy, lookup)` Returns strategy/selection exposure
-- `market_exposure(strategy, num_winners)` Returns strategy/market exposure (default num_winners=1)
+- `market_exposure(strategy, num_runners, num_winners)` Returns strategy/market exposure (default num_winners=1)
 
 ### Properties
 

--- a/docs/markets.md
+++ b/docs/markets.md
@@ -59,6 +59,7 @@ The blotter is a simple and fast class to hold all orders for a particular marke
 - `strategy_orders(strategy)` Returns all orders related to a strategy
 - `strategy_selection_orders(strategy, selection_id, handicap)` Returns all orders related to a strategy selection
 - `selection_exposure(strategy, lookup)` Returns strategy/selection exposure
+- `market_exposure(strategy, num_winners)` Returns strategy/market exposure
 
 ### Properties
 

--- a/docs/markets.md
+++ b/docs/markets.md
@@ -59,7 +59,7 @@ The blotter is a simple and fast class to hold all orders for a particular marke
 - `strategy_orders(strategy)` Returns all orders related to a strategy
 - `strategy_selection_orders(strategy, selection_id, handicap)` Returns all orders related to a strategy selection
 - `selection_exposure(strategy, lookup)` Returns strategy/selection exposure
-- `market_exposure(strategy, num_winners)` Returns strategy/market exposure
+- `market_exposure(strategy, num_winners)` Returns strategy/market exposure (default num_winners=1)
 
 ### Properties
 

--- a/flumine/markets/blotter.py
+++ b/flumine/markets/blotter.py
@@ -104,7 +104,7 @@ class Blotter:
 
     """ position """
 
-    def market_exposure(self, strategy, num_winners) -> float:
+    def market_exposure(self, strategy, num_winners: int = 1) -> float:
         """Returns worst-case exposure for market, which is the maximum potential loss (negative),
         arising from the worst race outcome, or the minimum potential profit (positive).
         """

--- a/flumine/markets/blotter.py
+++ b/flumine/markets/blotter.py
@@ -2,7 +2,6 @@ import logging
 from typing import Iterable, Optional
 from collections import defaultdict
 
-from ..markets.market import Market
 from ..order.ordertype import OrderTypes
 from ..utils import (
     calculate_unmatched_exposure,
@@ -104,12 +103,10 @@ class Blotter:
 
     """ position """
 
-    def market_exposure(self, strategy, market: Market) -> float:
+    def market_exposure(self, strategy, num_runners, num_winners: int = 1) -> float:
         """Returns worst-case exposure for market, which is the maximum potential loss (negative),
         arising from the worst race outcome, or the minimum potential profit (positive).
         """
-        num_runners = market.market_book.number_of_runners
-        num_winners = market.market_book.number_of_winners
         orders = self.strategy_orders(strategy)
         runners = set([order.lookup for order in orders])
         worst_possible_profits = [

--- a/flumine/markets/blotter.py
+++ b/flumine/markets/blotter.py
@@ -110,12 +110,21 @@ class Blotter:
         """
         orders = self.strategy_orders(strategy)
         runners = set([order.lookup for order in orders])
-        worst_possible_profits_on_wins = [self.get_exposures(strategy, lookup)["worst_possible_profit_on_win"] for lookup in runners]
-        worst_possible_profits_on_loses = [self.get_exposures(strategy, lookup)["worst_possible_profit_on_lose"] for lookup in runners]
-        differences = map(operator.sub, worst_possible_profits_on_wins, worst_possible_profits_on_loses)
-        worst_differences = sorted(differences)[:num_winners] # sorted puts smallest (i.e. biggest negative) first
+        worst_possible_profits_on_wins = [
+            self.get_exposures(strategy, lookup)["worst_possible_profit_on_win"]
+            for lookup in runners
+        ]
+        worst_possible_profits_on_loses = [
+            self.get_exposures(strategy, lookup)["worst_possible_profit_on_lose"]
+            for lookup in runners
+        ]
+        differences = map(
+            operator.sub,
+            worst_possible_profits_on_wins,
+            worst_possible_profits_on_loses,
+        )
+        worst_differences = sorted(differences)[:num_winners]
         return sum(worst_possible_profits_on_loses) + sum(worst_differences)
-
 
     def selection_exposure(self, strategy, lookup: tuple) -> float:
         """Returns strategy/selection exposure, which is the worse-case loss arising

--- a/flumine/markets/blotter.py
+++ b/flumine/markets/blotter.py
@@ -2,6 +2,7 @@ import logging
 from typing import Iterable, Optional
 from collections import defaultdict
 
+from ..markets.market import Market
 from ..order.ordertype import OrderTypes
 from ..utils import (
     calculate_unmatched_exposure,
@@ -103,10 +104,12 @@ class Blotter:
 
     """ position """
 
-    def market_exposure(self, strategy, num_runners, num_winners: int = 1) -> float:
+    def market_exposure(self, strategy, market: Market) -> float:
         """Returns worst-case exposure for market, which is the maximum potential loss (negative),
         arising from the worst race outcome, or the minimum potential profit (positive).
         """
+        num_runners = market.market_book.number_of_runners
+        num_winners = market.market_book.number_of_winners
         orders = self.strategy_orders(strategy)
         runners = set([order.lookup for order in orders])
         worst_possible_profits = [

--- a/flumine/markets/blotter.py
+++ b/flumine/markets/blotter.py
@@ -1,5 +1,4 @@
 import logging
-import operator
 from typing import Iterable, Optional
 from collections import defaultdict
 

--- a/flumine/markets/blotter.py
+++ b/flumine/markets/blotter.py
@@ -111,12 +111,10 @@ class Blotter:
         orders = self.strategy_orders(strategy)
         runners = set([order.lookup for order in orders])
         worst_possible_profits = [
-            self.get_exposures(strategy, lookup)
-            for lookup in runners
+            self.get_exposures(strategy, lookup) for lookup in runners
         ]
         worst_possible_profits_on_loses = [
-            wpp["worst_possible_profit_on_lose"]
-            for wpp in worst_possible_profits
+            wpp["worst_possible_profit_on_lose"] for wpp in worst_possible_profits
         ]
         differences = [
             wpp["worst_possible_profit_on_win"] - wpp["worst_possible_profit_on_lose"]

--- a/flumine/markets/blotter.py
+++ b/flumine/markets/blotter.py
@@ -110,19 +110,18 @@ class Blotter:
         """
         orders = self.strategy_orders(strategy)
         runners = set([order.lookup for order in orders])
-        worst_possible_profits_on_wins = [
-            self.get_exposures(strategy, lookup)["worst_possible_profit_on_win"]
+        worst_possible_profits = [
+            self.get_exposures(strategy, lookup)
             for lookup in runners
         ]
         worst_possible_profits_on_loses = [
-            self.get_exposures(strategy, lookup)["worst_possible_profit_on_lose"]
-            for lookup in runners
+            wpp["worst_possible_profit_on_lose"]
+            for wpp in worst_possible_profits
         ]
-        differences = map(
-            operator.sub,
-            worst_possible_profits_on_wins,
-            worst_possible_profits_on_loses,
-        )
+        differences = [
+            wpp["worst_possible_profit_on_win"] - wpp["worst_possible_profit_on_lose"]
+            for wpp in worst_possible_profits
+        ]
         worst_differences = sorted(differences)[:num_winners]
         return sum(worst_possible_profits_on_loses) + sum(worst_differences)
 

--- a/flumine/markets/blotter.py
+++ b/flumine/markets/blotter.py
@@ -1,4 +1,5 @@
 import logging
+import operator
 from typing import Iterable, Optional
 from collections import defaultdict
 
@@ -102,6 +103,19 @@ class Blotter:
         return [order for order in self]
 
     """ position """
+
+    def market_exposure(self, strategy, num_winners) -> float:
+        """Returns worst-case exposure for market, which is the maximum potential loss (negative),
+        arising from the worst race outcome, or the minimum potential profit (positive).
+        """
+        orders = self.strategy_orders(strategy)
+        runners = set([order.lookup for order in orders])
+        worst_possible_profits_on_wins = [self.get_exposures(strategy, lookup)["worst_possible_profit_on_win"] for lookup in runners]
+        worst_possible_profits_on_loses = [self.get_exposures(strategy, lookup)["worst_possible_profit_on_lose"] for lookup in runners]
+        differences = map(operator.sub, worst_possible_profits_on_wins, worst_possible_profits_on_loses)
+        worst_differences = sorted(differences)[:num_winners] # sorted puts smallest (i.e. biggest negative) first
+        return sum(worst_possible_profits_on_loses) + sum(worst_differences)
+
 
     def selection_exposure(self, strategy, lookup: tuple) -> float:
         """Returns strategy/selection exposure, which is the worse-case loss arising

--- a/flumine/markets/blotter.py
+++ b/flumine/markets/blotter.py
@@ -104,7 +104,7 @@ class Blotter:
 
     """ position """
 
-    def market_exposure(self, strategy, num_winners: int = 1) -> float:
+    def market_exposure(self, strategy, num_runners, num_winners: int = 1) -> float:
         """Returns worst-case exposure for market, which is the maximum potential loss (negative),
         arising from the worst race outcome, or the minimum potential profit (positive).
         """
@@ -119,7 +119,7 @@ class Blotter:
         differences = [
             wpp["worst_possible_profit_on_win"] - wpp["worst_possible_profit_on_lose"]
             for wpp in worst_possible_profits
-        ]
+        ] + (num_runners - len(runners)) * [0]
         worst_differences = sorted(differences)[:num_winners]
         return sum(worst_possible_profits_on_loses) + sum(worst_differences)
 

--- a/tests/test_blotter.py
+++ b/tests/test_blotter.py
@@ -475,13 +475,41 @@ class BlotterTest(unittest.TestCase):
                 complete=order[7],
             )
         self.assertEqual(  # single winner
-            self.blotter.market_exposure(mock_strategy), -20.2
+            self.blotter.market_exposure(mock_strategy, 6), -20.2
         )
         self.assertEqual(  # muliple winners
-            self.blotter.market_exposure(mock_strategy, 2), -24.6
+            self.blotter.market_exposure(mock_strategy, 6, 2), -24.6
         )
         self.assertEqual(  # num winmers > num runners traded
-            self.blotter.market_exposure(mock_strategy, 7), -28.6
+            self.blotter.market_exposure(mock_strategy, 20, 7), -28.6
+        )
+
+    def test_greened_market_position(self):
+        mock_strategy = mock.Mock()
+        mock_trade = mock.Mock(strategy=mock_strategy)
+        orders = [
+            # (order_id, selection_id, side, average_price_matched, size_matched, size_remaining, order_type, complete) 
+            (1001, 123, "BACK", 5.6, 2.0, 0.0, LimitOrder(price=5.6, size=2.0), True),
+            (1002, 123, "LAY", 5.2, 2.1, 0.0, LimitOrder(price=5.2, size=2.1), True),
+            (1003, 234, "BACK", 4.8, 4.0, 1.0, LimitOrder(price=4.8, size=5.0), True),
+            (1004, 234, "LAY", 4, 4.2, 1.0, LimitOrder(price=4, size=5.2), True),
+            (1005, 345, "BACK", 10, 2.0, 0.0, LimitOrder(price=10, size=2.0), False),
+            (1006, 345, "LAY", 8, 2.2, 0.0, LimitOrder(price=8, size=2.2), False),
+
+        ]
+        for order in orders:
+            self.blotter[order[0]] = mock.Mock(
+                trade=mock_trade,
+                lookup=(self.blotter.market_id, order[1], 0),
+                side=order[2],
+                average_price_matched=order[3],
+                size_matched=order[4],
+                size_remaining=order[5],
+                order_type=order[6],
+                complete=order[7],
+            )
+        self.assertEqual(  # single winner
+            self.blotter.market_exposure(mock_strategy, 6), 0.5
         )
 
     def test_complete_order(self):

--- a/tests/test_blotter.py
+++ b/tests/test_blotter.py
@@ -442,6 +442,33 @@ class BlotterTest(unittest.TestCase):
             },
         )
 
+    def test_market_position(self):
+        mock_strategy = mock.Mock()
+        mock_trade = mock.Mock(strategy=mock_strategy)
+        order_data = [
+            # (order_id, selection_id, side, average_price_matched, size_matched, size_remaining, order_type, complete) 
+            (1001, 123, "BACK", 5.6, 2.0, 0.0, LimitOrder(price=5.6, size=2.0), True),
+            (1002, 123, "LAY", 5.2, 3.0, 0.0, LimitOrder(price=5.2, size=3.0), True),
+            (1003, 234, "LAY", 4.8, 4.0, 1.0, LimitOrder(price=4.8, size=5.0), True),
+            (1004, 456, "BACK", None, 0.0, 0.0, LimitOrder(price=5.6, size=2.0), False),
+            (1005, 678, "BACK", None, None, None, MarketOnCloseOrder(liability=6.0), False),
+            (1006, 678, "LAY", None, None, None, LimitOnCloseOrder(price=1.01, liability=10.0), False),
+        ]
+        for order in order_data:
+            self.blotter[order[0]] = mock.Mock(
+                trade=mock_trade,
+                lookup=(self.blotter.market_id, order[1], 0),
+                side=order[2],
+                average_price_matched=order[3],
+                size_matched=order[4],
+                size_remaining=order[5],
+                order_type=order[6],
+                complete=order[7],
+        )
+        self.assertEqual(self.blotter.market_exposure(mock_strategy, 1), -20.2) # single winner
+        self.assertEqual(self.blotter.market_exposure(mock_strategy, 2), -24.6) # muliple winners
+        self.assertEqual(self.blotter.market_exposure(mock_strategy, 7), -28.6) # num winmers > num runners traded
+
     def test_complete_order(self):
         self.blotter._live_orders = ["test"]
         self.blotter.complete_order("test")

--- a/tests/test_blotter.py
+++ b/tests/test_blotter.py
@@ -488,14 +488,13 @@ class BlotterTest(unittest.TestCase):
         mock_strategy = mock.Mock()
         mock_trade = mock.Mock(strategy=mock_strategy)
         orders = [
-            # (order_id, selection_id, side, average_price_matched, size_matched, size_remaining, order_type, complete) 
+            # (order_id, selection_id, side, average_price_matched, size_matched, size_remaining, order_type, complete)
             (1001, 123, "BACK", 5.6, 2.0, 0.0, LimitOrder(price=5.6, size=2.0), True),
             (1002, 123, "LAY", 5.2, 2.1, 0.0, LimitOrder(price=5.2, size=2.1), True),
-            (1003, 234, "BACK", 4.8, 4.0, 1.0, LimitOrder(price=4.8, size=5.0), True),
-            (1004, 234, "LAY", 4, 4.2, 1.0, LimitOrder(price=4, size=5.2), True),
-            (1005, 345, "BACK", 10, 2.0, 0.0, LimitOrder(price=10, size=2.0), False),
-            (1006, 345, "LAY", 8, 2.2, 0.0, LimitOrder(price=8, size=2.2), False),
-
+            (1003, 234, "BACK", 4.8, 4.0, 1.0, LimitOrder(price=4.8, size=5.0), False),
+            (1004, 234, "LAY", 4, 4.2, 1.0, LimitOrder(price=4, size=5.2), False),
+            (1005, 345, "BACK", 10, 2.0, 0.0, LimitOrder(price=10, size=2.0), True),
+            (1006, 345, "LAY", 8, 2.2, 0.0, LimitOrder(price=8, size=2.2), True),
         ]
         for order in orders:
             self.blotter[order[0]] = mock.Mock(

--- a/tests/test_blotter.py
+++ b/tests/test_blotter.py
@@ -475,7 +475,7 @@ class BlotterTest(unittest.TestCase):
                 complete=order[7],
             )
         self.assertEqual(  # single winner
-            self.blotter.market_exposure(mock_strategy, 1), -20.2
+            self.blotter.market_exposure(mock_strategy), -20.2
         )
         self.assertEqual(  # muliple winners
             self.blotter.market_exposure(mock_strategy, 2), -24.6

--- a/tests/test_blotter.py
+++ b/tests/test_blotter.py
@@ -491,8 +491,8 @@ class BlotterTest(unittest.TestCase):
             # (order_id, selection_id, side, average_price_matched, size_matched, size_remaining, order_type, complete)
             (1001, 123, "BACK", 5.6, 2.0, 0.0, LimitOrder(price=5.6, size=2.0), True),
             (1002, 123, "LAY", 5.2, 2.1, 0.0, LimitOrder(price=5.2, size=2.1), True),
-            (1003, 234, "BACK", 4.8, 4.0, 1.0, LimitOrder(price=4.8, size=5.0), False),
-            (1004, 234, "LAY", 4, 4.2, 1.0, LimitOrder(price=4, size=5.2), False),
+            (1003, 234, "BACK", 4.8, 4.0, 0.0, LimitOrder(price=4.8, size=4.0), True),
+            (1004, 234, "LAY", 4, 4.2, 0.0, LimitOrder(price=4, size=4.2), True),
             (1005, 345, "BACK", 10, 2.0, 0.0, LimitOrder(price=10, size=2.0), True),
             (1006, 345, "LAY", 8, 2.2, 0.0, LimitOrder(price=8, size=2.2), True),
         ]


### PR DESCRIPTION
Builds on the existing selection exposure calculations (which does the heavy lifting) to derive the worst case outcome (exposure) for the whole market.

The underlying approach is to sum all potential losses and then adjust to reflect the worst case for the given number of winners in the market.

Limitations: this will not work for multi-line markets (e,g, each way, or most asian handicaps) or markets with a variable number of winners such as correct score for which Betfair treats each line as a separate market.