### PR TITLE
Passing market book object avoids need to pass individual parameters when calculating market exposure.

### DIFF
--- a/docs/markets.md
+++ b/docs/markets.md
@@ -59,7 +59,7 @@ The blotter is a simple and fast class to hold all orders for a particular marke
 - `strategy_orders(strategy)` Returns all orders related to a strategy
 - `strategy_selection_orders(strategy, selection_id, handicap)` Returns all orders related to a strategy selection
 - `selection_exposure(strategy, lookup)` Returns strategy/selection exposure
-- `market_exposure(strategy, num_runners, num_winners)` Returns strategy/market exposure (default num_winners=1)
+- `market_exposure(strategy, market_book)` Returns strategy/market exposure
 
 ### Properties
 

--- a/flumine/markets/blotter.py
+++ b/flumine/markets/blotter.py
@@ -126,7 +126,7 @@ class Blotter:
             wpp["worst_possible_profit_on_win"] - wpp["worst_possible_profit_on_lose"]
             for wpp in worst_possible_profits
         ] + (market_book.number_of_active_runners - len(runners)) * [0]
-        worst_differences = sorted(differences)[:market_book.number_of_winners]
+        worst_differences = sorted(differences)[: market_book.number_of_winners]
         return sum(worst_possible_profits_on_loses) + sum(worst_differences)
 
     def selection_exposure(self, strategy, lookup: tuple) -> float:

--- a/flumine/markets/blotter.py
+++ b/flumine/markets/blotter.py
@@ -110,7 +110,7 @@ class Blotter:
 
     """ position """
 
-    def market_exposure(self, strategy, num_runners, num_winners: int = 1) -> float:
+    def market_exposure(self, strategy, market_book) -> float:
         """Returns worst-case exposure for market, which is the maximum potential loss (negative),
         arising from the worst race outcome, or the minimum potential profit (positive).
         """
@@ -125,8 +125,8 @@ class Blotter:
         differences = [
             wpp["worst_possible_profit_on_win"] - wpp["worst_possible_profit_on_lose"]
             for wpp in worst_possible_profits
-        ] + (num_runners - len(runners)) * [0]
-        worst_differences = sorted(differences)[:num_winners]
+        ] + (market_book.number_of_active_runners - len(runners)) * [0]
+        worst_differences = sorted(differences)[:market_book.number_of_winners]
         return sum(worst_possible_profits_on_loses) + sum(worst_differences)
 
     def selection_exposure(self, strategy, lookup: tuple) -> float:

--- a/tests/test_blotter.py
+++ b/tests/test_blotter.py
@@ -481,18 +481,23 @@ class BlotterTest(unittest.TestCase):
                 order_type=order[6],
                 complete=order[7],
             )
+
+        mock_market_book = mock.Mock(number_of_active_runners=6, number_of_winners=1)
         self.assertEqual(  # single winner
-            self.blotter.market_exposure(mock_strategy, 6), -20.2
+            self.blotter.market_exposure(mock_strategy, mock_market_book), -20.2
         )
+        mock_market_book = mock.Mock(number_of_active_runners=6, number_of_winners=2)
         self.assertEqual(  # muliple winners
-            self.blotter.market_exposure(mock_strategy, 6, 2), -24.6
+            self.blotter.market_exposure(mock_strategy, mock_market_book), -24.6
         )
-        self.assertEqual(  # num winmers > num runners traded
-            self.blotter.market_exposure(mock_strategy, 20, 7), -28.6
+        mock_market_book = mock.Mock(number_of_active_runners=20, number_of_winners=7)
+        self.assertEqual(  # num winners > num runners traded
+            self.blotter.market_exposure(mock_strategy, mock_market_book), -28.6
         )
 
     def test_greened_market_position(self):
         mock_strategy = mock.Mock()
+        mock_market_book = mock.Mock(number_of_active_runners=6, number_of_winners=1)
         mock_trade = mock.Mock(strategy=mock_strategy)
         orders = [
             # (order_id, selection_id, side, average_price_matched, size_matched, size_remaining, order_type, complete)
@@ -515,7 +520,7 @@ class BlotterTest(unittest.TestCase):
                 complete=order[7],
             )
         self.assertEqual(  # single winner
-            self.blotter.market_exposure(mock_strategy, 6), 0.5
+            self.blotter.market_exposure(mock_strategy, mock_market_book), 0.5
         )
 
     def test_complete_order(self):


### PR DESCRIPTION
Breaking change as two integer parameters are replaced by a market_book instance.