### PR TITLE
Check if replace_order was all matched prior to replace order

### DIFF
--- a/flumine/order/order.py
+++ b/flumine/order/order.py
@@ -400,9 +400,13 @@ class BetfairOrder(BaseOrder):
         )
 
     def create_replace_instruction(self) -> dict:
-        return filters.replace_instruction(
-            bet_id=self.bet_id, new_price=self.update_data["new_price"]
-        )
+        if "new_price" not in self.update_data:
+            # No new_price available, previous order probably matched?
+            return {}
+        else:
+            return filters.replace_instruction(
+                bet_id=self.bet_id, new_price=self.update_data["new_price"]
+            )
 
     # currentOrder
     @property


### PR DESCRIPTION
Add a check in the backtest simulated execution for the cancelled order size, to ensure there is something left to replace.

Fixes: #548 

Signed-off-by: andrewl36 <andrew_m_leonard@hotmail.com>